### PR TITLE
Évite une montée de version mineure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
     include_package_data=True,
     install_requires = [
         'OpenFisca-Core >= 25, < 35',
-        'OpenFisca-France >= 47.1.0, < 49'
+        'OpenFisca-France >= 47.1.0, < 49',
+        'pytest == 5.3.5'
         ],
     extras_require = {
         'test': [


### PR DESCRIPTION
* En 5.4 un message d'avertissement apparaît vis à vis de la création des test YAML


La correction à faire sur Core n'est pas triviale. Je voudrais mettre ce paquet dans les mains de plus de personnes, cacher le message est une solution temporaire :sweat_smile: 