### PR TITLE
Ajoute des tests d'éligibilité à l'AdéFIP Eure-et-Loir

### DIFF
--- a/openfisca_france_local/departements/eure_et_loir/adefip.py
+++ b/openfisca_france_local/departements/eure_et_loir/adefip.py
@@ -1,5 +1,13 @@
  # -*- coding: utf-8 -*-
+from numpy import logical_not as not_
+
 from openfisca_france.model.base import Variable, Individu, MONTH
+
+class eure_et_loir_a_recu_adefip(Variable):
+    value_type = bool
+    entity = Individu
+    definition_period = MONTH
+    label = u"A perçu l'AdéFIP dans les 12 derniers mois"
 
 
 class eure_et_loir_eligibilite_adefip(Variable):
@@ -11,5 +19,6 @@ class eure_et_loir_eligibilite_adefip(Variable):
     def formula(individu, period):
         recoit_rsa = individu.famille('rsa', period) > 0
         reside_eure_et_loir = individu.menage('eure_et_loir_eligibilite_residence', period)
+        eure_et_loir_a_recu_adefip = individu('eure_et_loir_a_recu_adefip', period)
 
-        return recoit_rsa * reside_eure_et_loir
+        return not_(eure_et_loir_a_recu_adefip) * recoit_rsa * reside_eure_et_loir

--- a/openfisca_france_local/departements/eure_et_loir/adefip.py
+++ b/openfisca_france_local/departements/eure_et_loir/adefip.py
@@ -3,11 +3,11 @@ from numpy import logical_not as not_
 
 from openfisca_france.model.base import Variable, Individu, MONTH
 
-class eure_et_loir_a_recu_adefip(Variable):
+class eure_et_loir_adefip_versee(Variable):
     value_type = bool
     entity = Individu
     definition_period = MONTH
-    label = u"A perçu l'AdéFIP dans les 12 derniers mois"
+    label = u"AdéFIP versée en une fois dans les 12 derniers mois"
 
 
 class eure_et_loir_eligibilite_adefip(Variable):
@@ -19,6 +19,6 @@ class eure_et_loir_eligibilite_adefip(Variable):
     def formula(individu, period):
         recoit_rsa = individu.famille('rsa', period) > 0
         reside_eure_et_loir = individu.menage('eure_et_loir_eligibilite_residence', period)
-        eure_et_loir_a_recu_adefip = individu('eure_et_loir_a_recu_adefip', period)
+        eure_et_loir_adefip_versee = individu('eure_et_loir_adefip_versee', period)
 
-        return not_(eure_et_loir_a_recu_adefip) * recoit_rsa * reside_eure_et_loir
+        return not_(eure_et_loir_adefip_versee) * recoit_rsa * reside_eure_et_loir

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="0.17.0",
+    version="0.17.1",
     description="Extension OpenFisca pour nos partenariats avec les collectivités territoriales",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     author="",

--- a/tests/departements/eure_et_loir/adefip.yml
+++ b/tests/departements/eure_et_loir/adefip.yml
@@ -8,8 +8,29 @@
 - name: Cas réel 1
   period: 2020-06
   input:
-    date_naissance: '1990-12-01'
-    rsa: 704.65
-    eure_et_loir_eligibilite_residence: true
+    individus:
+      cas_reel_1:
+        date_naissance: '1990-12-01'
+      personne_a_charge_1:
+        date_naissance: '2018-01-01'
+      personne_a_charge_2:
+        date_naissance: '2017-01-01'
+      personne_a_charge_3:
+        date_naissance: '2016-01-01'
+    famille:
+       parents:
+       - cas_reel_1
+       enfants: [personne_a_charge_1, personne_a_charge_2, personne_a_charge_3]
+       rsa: 704.65
+    menage:
+      personne_de_reference:
+      - cas_reel_1
+      enfants: [personne_a_charge_1, personne_a_charge_2, personne_a_charge_3]
+      depcom: 28400
+    foyer_fiscal:
+      declarants:
+      - cas_reel_1
+      personnes_a_charge: [personne_a_charge_1, personne_a_charge_2, personne_a_charge_3]
   output:
+    eure_et_loir_eligibilite_residence: true
     eure_et_loir_eligibilite_adefip: true

--- a/tests/departements/eure_et_loir/adefip.yml
+++ b/tests/departements/eure_et_loir/adefip.yml
@@ -82,7 +82,7 @@
     individus:
       cas_reel_3:
         date_naissance: '1988-08-01'
-        eure_et_loir_a_recu_adefip: true
+        eure_et_loir_adefip_versee: true
     famille:
        parents:
        - cas_reel_3

--- a/tests/departements/eure_et_loir/adefip.yml
+++ b/tests/departements/eure_et_loir/adefip.yml
@@ -40,7 +40,7 @@
   period: 2019-12
   input:
     individus:
-      cas_reel_1:
+      cas_reel_2:
         date_naissance: '1986-09-01'
       enfant_1:
         date_naissance: '2012-01-01'
@@ -50,17 +50,69 @@
         date_naissance: '2016-01-01'
     famille:
        parents:
-       - cas_reel_1
+       - cas_reel_2
        enfants: [enfant_1, enfant_2, enfant_3]
        rsa: 759.42
     menage:
       personne_de_reference:
-      - cas_reel_1
+      - cas_reel_2
       enfants: [enfant_1, enfant_2, enfant_3]
       depcom: 28100
     foyer_fiscal:
       declarants:
-      - cas_reel_1
+      - cas_reel_2
+      personnes_a_charge: [enfant_1, enfant_2, enfant_3]
+  output:
+    eure_et_loir_eligibilite_residence: true
+    eure_et_loir_eligibilite_adefip: true
+
+- name: Cas réel 3
+  period: 2020-02
+  input:
+    individus:
+      cas_reel_3:
+        date_naissance: '1988-08-01'
+        eure_et_loir_a_recu_adefip: true
+    famille:
+       parents:
+       - cas_reel_3
+       rsa: 705.27
+    menage:
+      personne_de_reference:
+      - cas_reel_3
+      depcom: 28000
+    foyer_fiscal:
+      declarants:
+      - cas_reel_3
+  output:
+    eure_et_loir_eligibilite_residence: true
+    eure_et_loir_eligibilite_adefip: false
+
+- name: Cas réel 4
+  period: 2019-12
+  input:
+    individus:
+      cas_reel_4:
+        date_naissance: '1986-09-01'
+      enfant_1:
+        date_naissance: '2012-01-01'
+      enfant_2:
+        date_naissance: '2015-01-01'
+      enfant_3:
+        date_naissance: '2016-01-01'
+    famille:
+       parents:
+       - cas_reel_4
+       enfants: [enfant_1, enfant_2, enfant_3]
+       rsa: 759.42
+    menage:
+      personne_de_reference:
+      - cas_reel_4
+      enfants: [enfant_1, enfant_2, enfant_3]
+      depcom: 28100
+    foyer_fiscal:
+      declarants:
+      - cas_reel_4
       personnes_a_charge: [enfant_1, enfant_2, enfant_3]
   output:
     eure_et_loir_eligibilite_residence: true

--- a/tests/departements/eure_et_loir/adefip.yml
+++ b/tests/departements/eure_et_loir/adefip.yml
@@ -6,7 +6,9 @@
     eure_et_loir_eligibilite_adefip: [false, true, false, false]
 
 
-- name: Cas réel 1
+- name: Cas réel 1. [500€ AdéFIP attribué.] \
+    En CDD plus de 6 mois, en action d'insertion de 2019-12 à 2020-03. \
+    Personne seule et trois enfants. Perçoit le RSA.
   period: 2020-02
   input:
     individus:
@@ -22,7 +24,9 @@
        parents:
        - cas_reel_1
        enfants: [enfant_1, enfant_2, enfant_3]
-       rsa: 704.65
+       rsa: 
+        2020-02: 333.65
+        2019-12: 704.65
     menage:
       personne_de_reference:
       - cas_reel_1
@@ -37,7 +41,8 @@
     eure_et_loir_eligibilite_adefip: true
 
 
-- name: Cas réel 2
+- name: Cas réel 2. [700€ AdéFIP attribué.] \
+    En création d'entreprise en 2019-11. En couple et 3 enfants. Perçoit le RSA.
   period: 2019-12
   input:
     individus:
@@ -53,7 +58,8 @@
        parents:
        - cas_reel_2
        enfants: [enfant_1, enfant_2, enfant_3]
-       rsa: 759.42
+       rsa: 
+        2019-11: 759.42
     menage:
       personne_de_reference:
       - cas_reel_2

--- a/tests/departements/eure_et_loir/adefip.yml
+++ b/tests/departements/eure_et_loir/adefip.yml
@@ -6,31 +6,62 @@
     eure_et_loir_eligibilite_adefip: [false, true, false, false]
 
 - name: Cas réel 1
-  period: 2020-06
+  period: 2020-02
   input:
     individus:
       cas_reel_1:
         date_naissance: '1990-12-01'
-      personne_a_charge_1:
+      enfant_1:
         date_naissance: '2018-01-01'
-      personne_a_charge_2:
+      enfant_2:
         date_naissance: '2017-01-01'
-      personne_a_charge_3:
+      enfant_3:
         date_naissance: '2016-01-01'
     famille:
        parents:
        - cas_reel_1
-       enfants: [personne_a_charge_1, personne_a_charge_2, personne_a_charge_3]
+       enfants: [enfant_1, enfant_2, enfant_3]
        rsa: 704.65
     menage:
       personne_de_reference:
       - cas_reel_1
-      enfants: [personne_a_charge_1, personne_a_charge_2, personne_a_charge_3]
+      enfants: [enfant_1, enfant_2, enfant_3]
       depcom: 28400
     foyer_fiscal:
       declarants:
       - cas_reel_1
-      personnes_a_charge: [personne_a_charge_1, personne_a_charge_2, personne_a_charge_3]
+      personnes_a_charge: [enfant_1, enfant_2, enfant_3]
+  output:
+    eure_et_loir_eligibilite_residence: true
+    eure_et_loir_eligibilite_adefip: true
+
+
+- name: Cas réel 2
+  period: 2019-12
+  input:
+    individus:
+      cas_reel_1:
+        date_naissance: '1986-09-01'
+      enfant_1:
+        date_naissance: '2012-01-01'
+      enfant_2:
+        date_naissance: '2015-01-01'
+      enfant_3:
+        date_naissance: '2016-01-01'
+    famille:
+       parents:
+       - cas_reel_1
+       enfants: [enfant_1, enfant_2, enfant_3]
+       rsa: 759.42
+    menage:
+      personne_de_reference:
+      - cas_reel_1
+      enfants: [enfant_1, enfant_2, enfant_3]
+      depcom: 28100
+    foyer_fiscal:
+      declarants:
+      - cas_reel_1
+      personnes_a_charge: [enfant_1, enfant_2, enfant_3]
   output:
     eure_et_loir_eligibilite_residence: true
     eure_et_loir_eligibilite_adefip: true

--- a/tests/departements/eure_et_loir/adefip.yml
+++ b/tests/departements/eure_et_loir/adefip.yml
@@ -5,6 +5,7 @@
   output:
     eure_et_loir_eligibilite_adefip: [false, true, false, false]
 
+
 - name: Cas réel 1
   period: 2020-02
   input:
@@ -89,7 +90,7 @@
     eure_et_loir_eligibilite_adefip: false
 
 - name: Cas réel 4
-  period: 2019-12
+  period: 2020-02
   input:
     individus:
       cas_reel_4:
@@ -104,12 +105,12 @@
        parents:
        - cas_reel_4
        enfants: [enfant_1, enfant_2, enfant_3]
-       rsa: 759.42
+       rsa: 559.74
     menage:
       personne_de_reference:
       - cas_reel_4
       enfants: [enfant_1, enfant_2, enfant_3]
-      depcom: 28100
+      depcom: 28000
     foyer_fiscal:
       declarants:
       - cas_reel_4

--- a/tests/departements/eure_et_loir/adefip.yml
+++ b/tests/departements/eure_et_loir/adefip.yml
@@ -4,3 +4,12 @@
     eure_et_loir_eligibilite_residence: [true, true, false, false]
   output:
     eure_et_loir_eligibilite_adefip: [false, true, false, false]
+
+- name: Cas réel 1
+  period: 2020-06
+  input:
+    date_naissance: '1990-12-01'
+    rsa: 704.65
+    eure_et_loir_eligibilite_residence: true
+  output:
+    eure_et_loir_eligibilite_adefip: true

--- a/tests/departements/eure_et_loir/adefip.yml
+++ b/tests/departements/eure_et_loir/adefip.yml
@@ -24,7 +24,7 @@
        parents:
        - cas_reel_1
        enfants: [enfant_1, enfant_2, enfant_3]
-       rsa: 
+       rsa:
         2020-02: 333.65
         2019-12: 704.65
     menage:
@@ -58,7 +58,7 @@
        parents:
        - cas_reel_2
        enfants: [enfant_1, enfant_2, enfant_3]
-       rsa: 
+       rsa:
         2019-11: 759.42
     menage:
       personne_de_reference:
@@ -73,7 +73,10 @@
     eure_et_loir_eligibilite_residence: true
     eure_et_loir_eligibilite_adefip: true
 
-- name: Cas réel 3
+
+- name: Cas réel 3. AdéFIP non attribuée. \
+    A déjà bénéficié de l'AdéFIP en mars 2019 et formation 2019-12 à 2020-03 non qualifiante. \
+    Personne seule. Perçoit le RSA.
   period: 2020-02
   input:
     individus:
@@ -83,7 +86,8 @@
     famille:
        parents:
        - cas_reel_3
-       rsa: 705.27
+       rsa:
+        2020-01: 705.27
     menage:
       personne_de_reference:
       - cas_reel_3
@@ -95,12 +99,14 @@
     eure_et_loir_eligibilite_residence: true
     eure_et_loir_eligibilite_adefip: false
 
-- name: Cas réel 4
+- name: Cas réel 4. [400€ AdéFIP attribué.] \
+    En CDD de 3-6mois. En action d'insertionde 2019-12 à 04-2020. \
+    Personne seule. Perçoit le RSA.
   period: 2020-02
   input:
     individus:
       cas_reel_4:
-        date_naissance: '1986-09-01'
+        date_naissance: '1968-06-01'
       enfant_1:
         date_naissance: '2012-01-01'
       enfant_2:
@@ -111,7 +117,8 @@
        parents:
        - cas_reel_4
        enfants: [enfant_1, enfant_2, enfant_3]
-       rsa: 559.74
+       rsa:
+        2019-12: 559.74
     menage:
       personne_de_reference:
       - cas_reel_4


### PR DESCRIPTION
@Batouba, @frtomas Voici le contenu de cette PR. Je suis à votre disposition pour tout besoin de clarification.

* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : 
  * `openfisca_france_local/departements/eure_et_loir/adefip.py`
  * `tests/departements/eure_et_loir/adefip.yml`
* Détails :
  * Ajoute 4 cas de tests réels d'éligibilité à l'AdéFIP transcrits d'après les exemples fournis par le département
  * Ajoute la variable `eure_et_loir_adefip_versee`
