### PR TITLE
Met à jour la version OpenFisca France

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="0.15.0",
+    version="0.16.0",
     description="Extension OpenFisca pour nos partenariats avec les collectivités territoriales",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     author="",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     include_package_data=True,
     install_requires = [
         'OpenFisca-Core >= 25, < 36',
-        'OpenFisca-France >= 52, < 55',
+        'OpenFisca-France >= 52, < 57',
         'pandas == 1.0.3'
         ],
     extras_require = {


### PR DESCRIPTION
Met à jour la version d'OpenFisca France pour corriger les warnings Numpy traités dans la PR [#1580](https://github.com/openfisca/openfisca-france/pull/1580).