### PR TITLE
Augmente la version minimale d'openfisca france pour les aides permis MSA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="1.5.0",
+    version="1.6.0",
     description="Extension OpenFisca pour nos partenariats avec les collectivités territoriales",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     author="",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     include_package_data=True,
     install_requires = [
         'OpenFisca-Core >= 25, < 36',
-        'OpenFisca-France >= 61, < 77',
+        'OpenFisca-France >= 73.1, < 77',
         'pandas == 1.0.3'
         ],
     extras_require = {


### PR DESCRIPTION
Les aides permis MSA nécessitent la version 73.1 d'openfisca-france afin d'utiliser la variable `regime_securite_sociale`