### PR TITLE
Modélisation des tarifs périscolaire de strasbourg

### DIFF
--- a/openfisca_france_local/metropoles/strasbourg/tarification_acceuil_perisco_loisirs.py
+++ b/openfisca_france_local/metropoles/strasbourg/tarification_acceuil_perisco_loisirs.py
@@ -1,0 +1,39 @@
+from openfisca_france.model.base import Variable, Famille, MONTH, max_
+
+
+class strasbourg_metropole_quotient_familial(Variable):
+    value_type = float
+    entity = Famille
+    definition_period = MONTH
+    label = "Quotient familial de l'eurometropole de strasbourg"
+
+    # Note: pour le moment c'est le QF de la caf, mais à terme il poura evoluer pour se baser sur les revenus imposables
+    def formula(famille, period):
+        return (
+            famille.demandeur.foyer_fiscal("rfr", period.n_2)
+            / 12
+            / famille.demandeur.foyer_fiscal("nbptr", period.n_2)
+        )
+
+
+class strasbourg_metropole_tarification_mensuelle_acceuil_periscolaire_loisir_matin_soir(
+    Variable
+):
+    value_type = float
+    entity = Famille
+    definition_period = MONTH
+    definition_period = MONTH
+    label = "Tarification de l'acceuil periscolaire de l'Eurométropole de Strasbourg"
+    reference = [
+        # tarifs pour 2021-2022
+        "https://www.strasbourg.eu/documents/976405/1280877/0/0cc414e4-c6b7-1709-7e1e-46b088d28805"
+        # les tarifs 2202-2023 sont
+        # https://www.strasbourg.eu/documents/976405/1280877/0/c1917f09-97b2-2604-7d58-8b8cb5c0a849
+    ]
+
+    def formula(famille, period, parameters):
+        qf = famille("strasbourg_metropole_quotient_familial", period)
+        tarif = parameters(
+            period
+        ).metropoles.strasbourg.periscolaire.acceuil_matin_soir_maternelle
+        return tarif.calc(max_(0, qf), right=True)

--- a/openfisca_france_local/parameters/metropoles/strasbourg/periscolaire/acceuil_matin_soir_maternelle.yaml
+++ b/openfisca_france_local/parameters/metropoles/strasbourg/periscolaire/acceuil_matin_soir_maternelle.yaml
@@ -1,0 +1,69 @@
+description:
+  Tarif mensuel du service d'acceuil dans les écoles maternelles de la ville de strasbourg 
+metadata:
+    type: single_amount 
+    references:
+      - tarifs pour 2021-2022: "https://www.strasbourg.eu/documents/976405/1280877/0/0cc414e4-c6b7-1709-7e1e-46b088d28805"
+      # Non implémenté: 
+      # - tarifs 2202-2023 sont: https://www.strasbourg.eu/documents/976405/1280877/0/c1917f09-97b2-2604-7d58-8b8cb5c0a849
+brackets: 
+- threshold:
+    2021-01-01:
+      value: -1
+  amount:
+    2021-01-01: 
+      value: 11.95
+- threshold:
+    2021-01-01:
+      value: 410
+  amount:
+    2021-01-01: 
+      value: 16.70
+- threshold:
+    2021-01-01:
+      value: 510
+  amount:
+    2021-01-01: 
+      value: 21.50
+- threshold:
+    2021-01-01:
+      value: 620
+  amount:
+    2021-01-01: 
+      value: 26.25
+- threshold:
+    2021-01-01:
+      value: 720
+  amount:
+    2021-01-01: 
+      value: 31.10
+- threshold:
+    2021-01-01:
+      value: 820
+  amount:
+    2021-01-01: 
+      value: 35.85
+- threshold:
+    2021-01-01:
+      value: 920
+  amount:
+    2021-01-01: 
+      value: 40.60
+- threshold:
+    2021-01-01:
+      value: 1030
+  amount:
+    2021-01-01: 
+      value: 45.30
+- threshold:
+    2021-01-01:
+      value: 1540
+  amount:
+    2021-01-01: 
+      value: 50.15
+- threshold:
+    2021-01-01:
+      value: 2050
+  amount:
+    2021-01-01: 
+      value: 54.90

--- a/tests/metropoles/strasbourg/periscolaire.yaml
+++ b/tests/metropoles/strasbourg/periscolaire.yaml
@@ -1,0 +1,5 @@
+- period: 2021-10
+  input:
+    strasbourg_metropole_quotient_familial: [100, 1000, 3000]
+  output:
+    strasbourg_metropole_tarification_mensuelle_acceuil_periscolaire_loisir_matin_soir: [11.95, 40.60, 54.90]


### PR DESCRIPTION
Ajout de la grille tarifaire de l'acceuil matin/soir pour les écoles maternelle de strasbourg.