### PR TITLE
Fix - ajout du département de l'Isère dans la région AURA

### DIFF
--- a/openfisca_france_local/parameters/regions/auvergne_rhone_alpes/departements.yaml
+++ b/openfisca_france_local/parameters/regions/auvergne_rhone_alpes/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Auvergne Rhône Alpes
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: [ "01", "03", "07", "15", "26", "38", "42", "43", "63", "69", "73", "74" ]

--- a/openfisca_france_local/regions/auvergne_rhone_alpes/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/auvergne_rhone_alpes/eligibilite_residentielle.py
@@ -2,7 +2,7 @@ from openfisca_france.model.base import Variable, Menage, MONTH
 
 from numpy.core.defchararray import startswith
 
-DEPARTEMENT_AUVERGNE_RHONE_ALPES = [
+DEPARTEMENTS_AUVERGNE_RHONE_ALPES = [
     b'01', b'03', b'07', b'15', b'26', b'38', b'42', b'43', b'63', b'69', b'73', b'74'
 ]
 
@@ -15,4 +15,4 @@ class auvergne_rhone_alpes_eligibilite_residence(Variable):
 
     def formula(menage, period):
         depcom = menage('depcom', period)
-        return sum([startswith(depcom, code) for code in DEPARTEMENT_AUVERGNE_RHONE_ALPES]) > 0
+        return sum([startswith(depcom, code) for code in DEPARTEMENTS_AUVERGNE_RHONE_ALPES]) > 0

--- a/openfisca_france_local/regions/auvergne_rhone_alpes/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/auvergne_rhone_alpes/eligibilite_residentielle.py
@@ -2,10 +2,6 @@ from openfisca_france.model.base import Variable, Menage, MONTH
 
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_AUVERGNE_RHONE_ALPES = [
-    b'01', b'03', b'07', b'15', b'26', b'38', b'42', b'43', b'63', b'69', b'73', b'74'
-]
-
 
 class auvergne_rhone_alpes_eligibilite_residence(Variable):
     value_type = bool
@@ -13,6 +9,6 @@ class auvergne_rhone_alpes_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Auvergne-Rhône-Alpes."
 
-    def formula(menage, period):
+    def formula(menage, period, parameters):
         depcom = menage('depcom', period)
-        return sum([startswith(depcom, code) for code in DEPARTEMENTS_AUVERGNE_RHONE_ALPES]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.auvergne_rhone_alpes.departements]) > 0

--- a/openfisca_france_local/regions/auvergne_rhone_alpes/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/auvergne_rhone_alpes/eligibilite_residentielle.py
@@ -2,7 +2,10 @@ from openfisca_france.model.base import Variable, Menage, MONTH
 
 from numpy.core.defchararray import startswith
 
-DEPARTEMENT_AUVERGNE_RHONE_ALPES = [b'01', b'03', b'07', b'15', b'26', b'42', b'43', b'63', b'69', b'73', b'74']
+DEPARTEMENT_AUVERGNE_RHONE_ALPES = [
+    b'01', b'03', b'07', b'15', b'26', b'38', b'42', b'43', b'63', b'69', b'73', b'74'
+]
+
 
 class auvergne_rhone_alpes_eligibilite_residence(Variable):
     value_type = bool

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="4.2.0",
+    version="4.2.1",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
-    classifiers = [
+    classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: POSIX",
@@ -14,7 +14,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: Information Analysis",
-        ],
+    ],
     description="Extension OpenFisca pour nos partenariats avec les collectivités territoriales",
     keywords="benefit france france-local microsimulation social tax",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
@@ -22,18 +22,18 @@ setup(
 
     packages=find_packages(),
     include_package_data=True,
-    install_requires = [
+    install_requires=[
         'OpenFisca-Core >= 35.2.0, < 36',
         'OpenFisca-France >= 111.1, < 118',
         'pandas == 1.0.3'
-        ],
-    extras_require = {
+    ],
+    extras_require={
         'test': [
             'nose',
-            ],
+        ],
         'excel-reader': [
             'xlrd == 1.2.0'
-            ]
-        },
+        ]
+    },
     scripts=['openfisca_france_local/scripts/openfisca_local_test']
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version="4.2.1",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
-    classifiers=[
+    classifiers = [
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: POSIX",
@@ -14,7 +14,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: Information Analysis",
-    ],
+        ],
     description="Extension OpenFisca pour nos partenariats avec les collectivités territoriales",
     keywords="benefit france france-local microsimulation social tax",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
@@ -22,18 +22,18 @@ setup(
 
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[
+    install_requires = [
         'OpenFisca-Core >= 35.2.0, < 36',
         'OpenFisca-France >= 111.1, < 118',
         'pandas == 1.0.3'
-    ],
-    extras_require={
+        ],
+    extras_require = {
         'test': [
             'nose',
-        ],
+            ],
         'excel-reader': [
             'xlrd == 1.2.0'
-        ]
-    },
+            ]
+        },
     scripts=['openfisca_france_local/scripts/openfisca_local_test']
 )

--- a/tests/regions/auvergne-rhone-alpes/eligibilite_residentielle.yml
+++ b/tests/regions/auvergne-rhone-alpes/eligibilite_residentielle.yml
@@ -1,5 +1,5 @@
 - period: 2021-03
   input:
-    depcom: ["01100", "02000"]
+    depcom: ["01100", "02000", "38120"]
   output:
-    auvergne_rhone_alpes_eligibilite_residence: [true, false]
+    auvergne_rhone_alpes_eligibilite_residence: [true, false, true]


### PR DESCRIPTION
- La formule pour évaluer l'éligibilité de résidence dans la région Auvergne Rhône-Alpes ne prenait pas en compte le département de l'Isère