### PR TITLE
Ajouts eligibilités residentielle pour toutes les ŕegions manquantes

### DIFF
--- a/openfisca_france_local/parameters/regions/bourgogne_franche_comte/departements.yaml
+++ b/openfisca_france_local/parameters/regions/bourgogne_franche_comte/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Bourgogne Franche Comte
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["21", "25", "39", "58", "70", "71", "89", "90"]

--- a/openfisca_france_local/parameters/regions/bretagne/departements.yaml
+++ b/openfisca_france_local/parameters/regions/bretagne/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Bretagne
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["22", "29", "35", "56"]

--- a/openfisca_france_local/parameters/regions/centre_val_de_loire/departements.yaml
+++ b/openfisca_france_local/parameters/regions/centre_val_de_loire/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Centre Val de Loire
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["18", "28", "36", "37", "41", "45"]

--- a/openfisca_france_local/parameters/regions/corse/departements.yaml
+++ b/openfisca_france_local/parameters/regions/corse/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Corse
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["2A","2B",]

--- a/openfisca_france_local/parameters/regions/grand_est/departements.yaml
+++ b/openfisca_france_local/parameters/regions/grand_est/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Grand-Est
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["08", "10", "51", "52", "54", "55", "57", "67", "68", "88"]

--- a/openfisca_france_local/parameters/regions/guadeloupe/departements.yaml
+++ b/openfisca_france_local/parameters/regions/guadeloupe/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Guadeloupe
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["971"]

--- a/openfisca_france_local/parameters/regions/guyane/departements.yaml
+++ b/openfisca_france_local/parameters/regions/guyane/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Guyane
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["973"]

--- a/openfisca_france_local/parameters/regions/hauts_de_france/departements.yaml
+++ b/openfisca_france_local/parameters/regions/hauts_de_france/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Hauts de France
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["02", "59", "60", "62", "80"]

--- a/openfisca_france_local/parameters/regions/ile_de_france/departements.yaml
+++ b/openfisca_france_local/parameters/regions/ile_de_france/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Île de France
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["75","77","78","91","92","93","94","95"]

--- a/openfisca_france_local/parameters/regions/martinique/departements.yaml
+++ b/openfisca_france_local/parameters/regions/martinique/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Martinique
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["972"]

--- a/openfisca_france_local/parameters/regions/mayotte/departements.yaml
+++ b/openfisca_france_local/parameters/regions/mayotte/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Mayotte
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["976"]

--- a/openfisca_france_local/parameters/regions/normandie/departements.yaml
+++ b/openfisca_france_local/parameters/regions/normandie/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Normandie
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["14","27","50","61","76"]

--- a/openfisca_france_local/parameters/regions/nouvelle_aquitaine.yml
+++ b/openfisca_france_local/parameters/regions/nouvelle_aquitaine.yml
@@ -1,9 +1,0 @@
-carte_solidaire:
-  plafond:
-    values:
-      2009-01-01:
-        value: 870
-  reduction:
-    values:
-      2009-01-01:
-        value: 80

--- a/openfisca_france_local/parameters/regions/nouvelle_aquitaine/carte_solidaire.yml
+++ b/openfisca_france_local/parameters/regions/nouvelle_aquitaine/carte_solidaire.yml
@@ -1,0 +1,8 @@
+plafond:
+  values:
+    2009-01-01:
+      value: 870
+reduction:
+  values:
+    2009-01-01:
+      value: 80

--- a/openfisca_france_local/parameters/regions/nouvelle_aquitaine/departements.yaml
+++ b/openfisca_france_local/parameters/regions/nouvelle_aquitaine/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Nouvelle Aquitaine
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["16","17","19","23","24","33","40","47","64","79","86","87"]

--- a/openfisca_france_local/parameters/regions/occitanie/departements.yaml
+++ b/openfisca_france_local/parameters/regions/occitanie/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Occitanie
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["09", "11", "12", "30", "31", "32", "34", "46", "48", "65", "66", "81", "82"]

--- a/openfisca_france_local/parameters/regions/pays_de_la_loire/departements.yaml
+++ b/openfisca_france_local/parameters/regions/pays_de_la_loire/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Pays de la Loire
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["44","49","53","72","85"]

--- a/openfisca_france_local/parameters/regions/provence_alpes_cote_d_azur/departements.yaml
+++ b/openfisca_france_local/parameters/regions/provence_alpes_cote_d_azur/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Provence Alpes Côtes d'Azur
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["04","05","06","13","83","84"]

--- a/openfisca_france_local/parameters/regions/reunion/departements.yaml
+++ b/openfisca_france_local/parameters/regions/reunion/departements.yaml
@@ -1,0 +1,5 @@
+description: Liste des départements membre de la région Réunion
+unit: Code INSEE
+values:
+  2015-01-16:
+    value: ["974"]

--- a/openfisca_france_local/regions/auvergne_rhone_alpes/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/auvergne_rhone_alpes/eligibilite_residentielle.py
@@ -1,5 +1,7 @@
 from openfisca_france.model.base import Variable, Menage, MONTH
-
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
 
@@ -9,6 +11,6 @@ class auvergne_rhone_alpes_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Auvergne-Rhône-Alpes."
 
-    def formula(menage, period, parameters):
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom = menage('depcom', period)
         return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.auvergne_rhone_alpes.departements]) > 0

--- a/openfisca_france_local/regions/bourgogne_franche_comte/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/bourgogne_franche_comte/eligibilite_residentielle.py
@@ -1,0 +1,20 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENTS_BOURGOGNE_FRANCHE_COMTE = [
+    b'21', b'25', b'39', b'58', b'70', b'71', b'89', b'90'
+]
+
+
+class bourgogne_franche_comte_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Bourgogne Franche-Comté"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_BOURGOGNE_FRANCHE_COMTE]) > 0

--- a/openfisca_france_local/regions/bourgogne_franche_comte/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/bourgogne_franche_comte/eligibilite_residentielle.py
@@ -4,10 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_BOURGOGNE_FRANCHE_COMTE = [
-    b'21', b'25', b'39', b'58', b'70', b'71', b'89', b'90'
-]
-
 
 class bourgogne_franche_comte_eligibilite_residence(Variable):
     value_type = bool
@@ -15,6 +11,6 @@ class bourgogne_franche_comte_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Bourgogne Franche-Comté"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_BOURGOGNE_FRANCHE_COMTE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.bourgogne_franche_comte.departements]) > 0

--- a/openfisca_france_local/regions/bretagne/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/bretagne/eligibilite_residentielle.py
@@ -4,8 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_BRETAGNE = [b'22', b'29', b'35', b'56']
-
 
 class bretagne_eligibilite_residence(Variable):
     value_type = bool
@@ -13,6 +11,6 @@ class bretagne_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Bretagne"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_BRETAGNE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.bretagne.departements]) > 0

--- a/openfisca_france_local/regions/bretagne/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/bretagne/eligibilite_residentielle.py
@@ -1,0 +1,18 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENTS_BRETAGNE = [b'22', b'29', b'35', b'56']
+
+
+class bretagne_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Bretagne"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_BRETAGNE]) > 0

--- a/openfisca_france_local/regions/centre_val_de_loire/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/centre_val_de_loire/eligibilite_residentielle.py
@@ -3,8 +3,6 @@ from openfisca_core.populations.population import Population
 from openfisca_core.periods import Period
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_CENTRE_VAL_DE_LOIRE = [b'18', b'28', b'36', b'37', b'41', b'45']
-
 
 class centre_val_de_loire_eligibilite_residence(Variable):
     value_type = bool
@@ -12,6 +10,6 @@ class centre_val_de_loire_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région centre val de loire"
 
-    def formula(menage: Population, period: Period):
+    def formula(menage: Population, period: Period, parameters):
         depcom = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_CENTRE_VAL_DE_LOIRE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.centre_val_de_loire.departements]) > 0

--- a/openfisca_france_local/regions/centre_val_de_loire/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/centre_val_de_loire/eligibilite_residentielle.py
@@ -1,0 +1,17 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.defchararray import startswith
+
+DEPARTEMENTS_CENTRE_VAL_DE_LOIRE = [b'18', b'28', b'36', b'37', b'41', b'45']
+
+
+class centre_val_de_loire_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région centre val de loire"
+
+    def formula(menage: Population, period: Period):
+        depcom = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_CENTRE_VAL_DE_LOIRE]) > 0

--- a/openfisca_france_local/regions/corse/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/corse/eligibilite_residentielle.py
@@ -1,0 +1,21 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENTS_CORSE = [
+    b'2A',
+    b'2B',
+]
+
+
+class corse_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Corse"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_CORSE]) > 0

--- a/openfisca_france_local/regions/corse/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/corse/eligibilite_residentielle.py
@@ -4,11 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_CORSE = [
-    b'2A',
-    b'2B',
-]
-
 
 class corse_eligibilite_residence(Variable):
     value_type = bool
@@ -16,6 +11,6 @@ class corse_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Corse"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_CORSE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.corse.departements]) > 0

--- a/openfisca_france_local/regions/grand_est/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/grand_est/eligibilite_residentielle.py
@@ -1,0 +1,16 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+
+class grand_est_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Grand Est"
+
+    def formula(menage: Population, period: Period, parameters) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.grand_est.departements]) > 0

--- a/openfisca_france_local/regions/guadeloupe/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/guadeloupe/eligibilite_residentielle.py
@@ -6,8 +6,6 @@ from numpy.core.records import array as np_array
 
 from numpy.core.defchararray import startswith
 
-DEPARTEMENT_GUADELOUPE = [b'97']
-
 
 class guadeloupe_eligibilite_residence(Variable):
     value_type = bool
@@ -15,6 +13,6 @@ class guadeloupe_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Guadeloupe."
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code) for code in DEPARTEMENT_GUADELOUPE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.guadeloupe.departements]) > 0

--- a/openfisca_france_local/regions/guadeloupe/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/guadeloupe/eligibilite_residentielle.py
@@ -1,0 +1,20 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+
+from numpy.core.defchararray import startswith
+
+DEPARTEMENT_GUADELOUPE = [b'97']
+
+
+class guadeloupe_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Guadeloupe."
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code) for code in DEPARTEMENT_GUADELOUPE]) > 0

--- a/openfisca_france_local/regions/guyane/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/guyane/eligibilite_residentielle.py
@@ -1,0 +1,20 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENT_GUYANE = [
+    b'973',
+]
+
+
+class guyane_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Guyane"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_GUYANE]) > 0

--- a/openfisca_france_local/regions/guyane/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/guyane/eligibilite_residentielle.py
@@ -4,10 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENT_GUYANE = [
-    b'973',
-]
-
 
 class guyane_eligibilite_residence(Variable):
     value_type = bool
@@ -15,6 +11,6 @@ class guyane_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Guyane"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_GUYANE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.guyane.departements]) > 0

--- a/openfisca_france_local/regions/hauts_de_france/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/hauts_de_france/eligibilite_residentielle.py
@@ -1,0 +1,19 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+
+from numpy.core.defchararray import startswith
+
+DEPARTEMENTS_HAUTS_DE_FRANCE = [b'02', b'59', b'60', b'62', b'80']
+
+
+class hauts_de_france_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Hauts-de-France."
+
+    def formula(menage: Population, period: Period):
+        depcom = menage('depcom', period)
+        return sum([startswith(depcom, code) for code in DEPARTEMENTS_HAUTS_DE_FRANCE]) > 0

--- a/openfisca_france_local/regions/hauts_de_france/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/hauts_de_france/eligibilite_residentielle.py
@@ -5,8 +5,6 @@ from openfisca_core.periods import Period
 
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_HAUTS_DE_FRANCE = [b'02', b'59', b'60', b'62', b'80']
-
 
 class hauts_de_france_eligibilite_residence(Variable):
     value_type = bool
@@ -14,6 +12,6 @@ class hauts_de_france_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Hauts-de-France."
 
-    def formula(menage: Population, period: Period):
+    def formula(menage: Population, period: Period, parameters):
         depcom = menage('depcom', period)
-        return sum([startswith(depcom, code) for code in DEPARTEMENTS_HAUTS_DE_FRANCE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.hauts_de_france.departements]) > 0

--- a/openfisca_france_local/regions/ile_de_france/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/ile_de_france/eligibilite_residentielle.py
@@ -1,0 +1,27 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENTS_ILE_DE_FRANCE = [
+    b'75',
+    b'77',
+    b'78',
+    b'91',
+    b'92',
+    b'93',
+    b'94',
+    b'95',
+]
+
+
+class ile_de_france_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Ile de France"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_ILE_DE_FRANCE]) > 0

--- a/openfisca_france_local/regions/ile_de_france/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/ile_de_france/eligibilite_residentielle.py
@@ -4,17 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_ILE_DE_FRANCE = [
-    b'75',
-    b'77',
-    b'78',
-    b'91',
-    b'92',
-    b'93',
-    b'94',
-    b'95',
-]
-
 
 class ile_de_france_eligibilite_residence(Variable):
     value_type = bool
@@ -22,6 +11,6 @@ class ile_de_france_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Ile de France"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_ILE_DE_FRANCE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.ile_de_france.departements]) > 0

--- a/openfisca_france_local/regions/martinique/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/martinique/eligibilite_residentielle.py
@@ -1,0 +1,20 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENT_MARTINIQUE = [
+    b'972',
+]
+
+
+class martinique_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Martinique"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_MARTINIQUE]) > 0

--- a/openfisca_france_local/regions/martinique/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/martinique/eligibilite_residentielle.py
@@ -4,10 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENT_MARTINIQUE = [
-    b'972',
-]
-
 
 class martinique_eligibilite_residence(Variable):
     value_type = bool
@@ -15,6 +11,6 @@ class martinique_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Martinique"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_MARTINIQUE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.martinique.departements]) > 0

--- a/openfisca_france_local/regions/mayotte/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/mayotte/eligibilite_residentielle.py
@@ -1,0 +1,20 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENT_MAYOTTE = [
+    b'976',
+]
+
+
+class mayotte_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Mayotte"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_MAYOTTE]) > 0

--- a/openfisca_france_local/regions/mayotte/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/mayotte/eligibilite_residentielle.py
@@ -4,10 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENT_MAYOTTE = [
-    b'976',
-]
-
 
 class mayotte_eligibilite_residence(Variable):
     value_type = bool
@@ -15,6 +11,6 @@ class mayotte_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Mayotte"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_MAYOTTE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.mayotte.departements]) > 0

--- a/openfisca_france_local/regions/normandie/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/normandie/eligibilite_residentielle.py
@@ -1,0 +1,24 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENTS_NORMANDIE = [
+    b'14',
+    b'27',
+    b'50',
+    b'61',
+    b'76',
+]
+
+
+class normandie_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Normandie"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_NORMANDIE]) > 0

--- a/openfisca_france_local/regions/normandie/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/normandie/eligibilite_residentielle.py
@@ -4,14 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_NORMANDIE = [
-    b'14',
-    b'27',
-    b'50',
-    b'61',
-    b'76',
-]
-
 
 class normandie_eligibilite_residence(Variable):
     value_type = bool
@@ -19,6 +11,6 @@ class normandie_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Normandie"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_NORMANDIE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.normandie.departements]) > 0

--- a/openfisca_france_local/regions/nouvelle-aquitaine/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/nouvelle-aquitaine/eligibilite_residentielle.py
@@ -1,6 +1,7 @@
- # -*- coding: utf-8 -*-
 from openfisca_france.model.base import Variable, Menage, MONTH
-
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
 
@@ -8,22 +9,8 @@ class nouvelle_aquitaine_eligibilite_residence(Variable):
     value_type = bool
     entity = Menage
     definition_period = MONTH
-    label = u"Éligibilité résidentielle d'un ménage aux dipositifs de la Nouvelle Aquitaine"
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la Nouvelle Aquitaine"
 
-    def formula(menage, period):
-        code_departements = [b'16',
-          b'17',
-          b'19',
-          b'23',
-          b'24',
-          b'33',
-          b'40',
-          b'47',
-          b'64',
-          b'79',
-          b'86',
-          b'87'
-          ]
-
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom = menage('depcom', period)
-        return sum([startswith(depcom, code) for code in code_departements]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.nouvelle_aquitaine.departements]) > 0

--- a/openfisca_france_local/regions/occitanie/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/occitanie/eligibilite_residentielle.py
@@ -1,9 +1,9 @@
 from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_OCCITANIE = [
-    b"09", b"11", b"12", b"30", b"31", b"32", b"34", b"46", b"48", b"65", b"66", b"81", b"82"
-]
 
 class occitanie_eligibilite_residence(Variable):
     value_type = bool
@@ -11,7 +11,6 @@ class occitanie_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Occitanie"
 
-    def formula(menage, period):
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_OCCITANIE]) > 0
-
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.occitanie.departements]) > 0

--- a/openfisca_france_local/regions/pays_de_la_loire/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/pays_de_la_loire/eligibilite_residentielle.py
@@ -1,0 +1,24 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENTS_PAYS_DE_LA_LOIRE = [
+    b'44',
+    b'49',
+    b'53',
+    b'72',
+    b'85',
+]
+
+
+class pays_de_la_loire_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Pays de la Loire"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_PAYS_DE_LA_LOIRE]) > 0

--- a/openfisca_france_local/regions/pays_de_la_loire/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/pays_de_la_loire/eligibilite_residentielle.py
@@ -4,14 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_PAYS_DE_LA_LOIRE = [
-    b'44',
-    b'49',
-    b'53',
-    b'72',
-    b'85',
-]
-
 
 class pays_de_la_loire_eligibilite_residence(Variable):
     value_type = bool
@@ -19,6 +11,6 @@ class pays_de_la_loire_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Pays de la Loire"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_PAYS_DE_LA_LOIRE]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.pays_de_la_loire.departements]) > 0

--- a/openfisca_france_local/regions/provence_alpes_cote_d_azur/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/provence_alpes_cote_d_azur/eligibilite_residentielle.py
@@ -1,0 +1,25 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENT_PROVENCE_ALPES_COTE_D_AZUR = [
+    b'04',
+    b'05',
+    b'06',
+    b'13',
+    b'83',
+    b'84',
+]
+
+
+class provence_alpes_cote_d_azur_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Provence Alpes Cote d'Azur"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_PROVENCE_ALPES_COTE_D_AZUR]) > 0

--- a/openfisca_france_local/regions/provence_alpes_cote_d_azur/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/provence_alpes_cote_d_azur/eligibilite_residentielle.py
@@ -4,7 +4,7 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENT_PROVENCE_ALPES_COTE_D_AZUR = [
+DEPARTEMENTS_PROVENCE_ALPES_COTE_D_AZUR = [
     b'04',
     b'05',
     b'06',
@@ -22,4 +22,4 @@ class provence_alpes_cote_d_azur_eligibilite_residence(Variable):
 
     def formula(menage: Population, period: Period) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_PROVENCE_ALPES_COTE_D_AZUR]) > 0
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_PROVENCE_ALPES_COTE_D_AZUR]) > 0

--- a/openfisca_france_local/regions/provence_alpes_cote_d_azur/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/provence_alpes_cote_d_azur/eligibilite_residentielle.py
@@ -4,15 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENTS_PROVENCE_ALPES_COTE_D_AZUR = [
-    b'04',
-    b'05',
-    b'06',
-    b'13',
-    b'83',
-    b'84',
-]
-
 
 class provence_alpes_cote_d_azur_eligibilite_residence(Variable):
     value_type = bool
@@ -20,6 +11,6 @@ class provence_alpes_cote_d_azur_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Provence Alpes Cote d'Azur"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENTS_PROVENCE_ALPES_COTE_D_AZUR]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.provence_alpes_cote_d_azur.departements]) > 0

--- a/openfisca_france_local/regions/reunion/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/reunion/eligibilite_residentielle.py
@@ -4,10 +4,6 @@ from openfisca_core.periods import Period
 from numpy.core.records import array as np_array
 from numpy.core.defchararray import startswith
 
-DEPARTEMENT_REUNION = [
-    b'974',
-]
-
 
 class reunion_eligibilite_residence(Variable):
     value_type = bool
@@ -15,6 +11,6 @@ class reunion_eligibilite_residence(Variable):
     definition_period = MONTH
     label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Reunion"
 
-    def formula(menage: Population, period: Period) -> np_array:
+    def formula(menage: Population, period: Period, parameters) -> np_array:
         depcom: np_array = menage('depcom', period)
-        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_REUNION]) > 0
+        return sum([startswith(depcom, str.encode(code)) for code in parameters(period).regions.reunion.departements]) > 0

--- a/openfisca_france_local/regions/reunion/eligibilite_residentielle.py
+++ b/openfisca_france_local/regions/reunion/eligibilite_residentielle.py
@@ -1,0 +1,20 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+from openfisca_core.populations.population import Population
+from openfisca_core.periods import Period
+from numpy.core.records import array as np_array
+from numpy.core.defchararray import startswith
+
+DEPARTEMENT_REUNION = [
+    b'974',
+]
+
+
+class reunion_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de la région Reunion"
+
+    def formula(menage: Population, period: Period) -> np_array:
+        depcom: np_array = menage('depcom', period)
+        return sum([startswith(depcom, code_departement) for code_departement in DEPARTEMENT_REUNION]) > 0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="4.2.1",
+    version="4.3.0",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers = [

--- a/tests/regions/bourgogne_franche_comte/eligibilite_residentielle.yml
+++ b/tests/regions/bourgogne_franche_comte/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2021-10
+  input:
+    depcom: ["21213", "95563"]
+  output:
+    bourgogne_franche_comte_eligibilite_residence: [true, false]

--- a/tests/regions/bretagne/eligibilite_residentielle.yml
+++ b/tests/regions/bretagne/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["22278 ", "38430", "97300"]
+  output:
+    bretagne_eligibilite_residence: [true, false, false]

--- a/tests/regions/centre_val_de_loire/eligibilite_residentielle.yml
+++ b/tests/regions/centre_val_de_loire/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["45234 ", "38430", "97300"]
+  output:
+    centre_val_de_loire_eligibilite_residence: [true, false, false]

--- a/tests/regions/corse/eligibilite_residentielle.yml
+++ b/tests/regions/corse/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["2A004", "38430", "97300"]
+  output:
+    corse_eligibilite_residence: [true, false, false]

--- a/tests/regions/grand_est/eligibilite_residentielle.yml
+++ b/tests/regions/grand_est/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["67482", "38430", "97300"]
+  output:
+    grand_est_eligibilite_residence: [true, false, false]

--- a/tests/regions/guadeloupe/eligibilite_residentielle.yml
+++ b/tests/regions/guadeloupe/eligibilite_residentielle.yml
@@ -1,0 +1,6 @@
+- period: 2022-11
+  input:
+    depcom: ["97200", "68068", "91300"]
+  output:
+    guadeloupe_eligibilite_residence: [true, false, false]
+    

--- a/tests/regions/guadeloupe/eligibilite_residentielle.yml
+++ b/tests/regions/guadeloupe/eligibilite_residentielle.yml
@@ -1,6 +1,6 @@
 - period: 2022-11
   input:
-    depcom: ["97200", "68068", "91300"]
+    depcom: ["97100", "68068", "97200"]
   output:
     guadeloupe_eligibilite_residence: [true, false, false]
     

--- a/tests/regions/guyane/eligibilite_residentielle.yml
+++ b/tests/regions/guyane/eligibilite_residentielle.yml
@@ -1,0 +1,6 @@
+- period: 2022-11
+  input:
+    depcom: ["97200", "68068", "97300"]
+  output:
+    guyane_eligibilite_residence: [false, false, true]
+    

--- a/tests/regions/hauts-de-france/eligibilite_residentielle.yml
+++ b/tests/regions/hauts-de-france/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["02408 ", "38430", "97300"]
+  output:
+    hauts_de_france_eligibilite_residence: [true, false, false]

--- a/tests/regions/ile_de_france/eligibilite_residentielle.yml
+++ b/tests/regions/ile_de_france/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["75002", "38430", "97300"]
+  output:
+    ile_de_france_eligibilite_residence: [true, false, false]

--- a/tests/regions/martinique/eligibilite_residentielle.yml
+++ b/tests/regions/martinique/eligibilite_residentielle.yml
@@ -1,5 +1,5 @@
 - period: 2022-11
   input:
-    depcom: ["97200"]
+    depcom: ["97200", "38430", "97300"]
   output:
-    martinique_eligibilite_residence: [true]
+    martinique_eligibilite_residence: [true, false, false]

--- a/tests/regions/martinique/eligibilite_residentielle.yml
+++ b/tests/regions/martinique/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["97200"]
+  output:
+    martinique_eligibilite_residence: [true]

--- a/tests/regions/mayotte/eligibilite_residentielle.yml
+++ b/tests/regions/mayotte/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["97608", "38430", "97300"]
+  output:
+    mayotte_eligibilite_residence: [true, false, false]

--- a/tests/regions/normandie/eligibilite_residentielle.yml
+++ b/tests/regions/normandie/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["76540", "38430", "97300"]
+  output:
+    normandie_eligibilite_residence: [true, false, false]

--- a/tests/regions/nouvelle-aquitaine/eligibilite_residentielle.yml
+++ b/tests/regions/nouvelle-aquitaine/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["19272 ", "38430", "97300"]
+  output:
+    nouvelle_aquitaine_eligibilite_residence: [true, false, false]

--- a/tests/regions/occitanie/eligibilite_residentielle.yml
+++ b/tests/regions/occitanie/eligibilite_residentielle.yml
@@ -1,5 +1,5 @@
 - period: 2021-10
   input:
-    depcom: [31555, 95563]
+    depcom: ["31555", "95563"]
   output:
     occitanie_eligibilite_residence: [true, false]

--- a/tests/regions/pays_de_la_loire/eligibilite_residentielle.yml
+++ b/tests/regions/pays_de_la_loire/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["49007", "38430", "97300"]
+  output:
+    pays_de_la_loire_eligibilite_residence: [true, false, false]

--- a/tests/regions/provence_alpes_cote_d_azur/eligibilite_residentielle.yml
+++ b/tests/regions/provence_alpes_cote_d_azur/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["13055", "38430", "97300"]
+  output:
+    provence_alpes_cote_d_azur_eligibilite_residence: [true, false, false]

--- a/tests/regions/reunion/eligibilite_residentielle.yml
+++ b/tests/regions/reunion/eligibilite_residentielle.yml
@@ -1,0 +1,5 @@
+- period: 2022-11
+  input:
+    depcom: ["97411", "38430", "97300"]
+  output:
+    reunion_eligibilite_residence: [true, false, false]


### PR DESCRIPTION
Dans le cadre d'un travail mené par aides-jeunes, nous avons besoin d'évaluer l'éligibilité résidentielle dans toutes les régions.
Cette PR contient : 
- les variables en question pour les régions qui n'en avait pas
- les tests pour ces variables
- les tests pour les variables existantes qui en manquait
- Refacto de typage (ajout de types sur les paramètres et pour les valeurs de retours),
- Refacto des données de départements (les listes de département associés sont maintenant gérés par des paramètres)