### PR TITLE
Fix workflow - Python setup error : Python not found

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.12
+          python-version: 3.7
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.12
+          python-version: 3.7
       - name: Check version number has been properly updated
         run: "${GITHUB_WORKSPACE}/.github/is-version-number-acceptable.sh"
 
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.12
+          python-version: 3.7
       - id: stop-early
         run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "::set-output name=status::success" ; fi
 
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.12
+          python-version: 3.7
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.12
+          python-version: 3.7
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2


### PR DESCRIPTION
Le workflow github actions lève une erreur sur mes deux dernières PR : 
```
Error: Version 3.7.12 with arch x64 not found
```
Il semblerai que l'utilisation de la version majeure `3.7` résolve le problème.
La version installée quand on utilise cette valeur est la version `3.7.15` de Python.