### PR TITLE
Monté de version d'openfisca-france vers 139.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="4.2.2",
+    version="4.2.3",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers = [
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     install_requires = [
         'OpenFisca-Core >= 35.2.0, < 36',
-        'OpenFisca-France >= 111.1, < 137',
+        'OpenFisca-France >= 111.1, < 139.0.1',
         'pandas == 1.0.3'
         ],
     extras_require = {


### PR DESCRIPTION
## Détails

La version 139.0.0 contient l'ajout de la variable `region` nécessaire pour certains de nos travaux.