### PR TITLE
Mise à jour OpenFisca-France vers version 142.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="4.2.3",
+    version="4.2.4",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers = [
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     install_requires = [
         'OpenFisca-Core >= 35.2.0, < 36',
-        'OpenFisca-France >= 111.1, < 139.0.1',
+        'OpenFisca-France >= 141.0.0, < 142.0.1',
         'pandas == 1.0.3'
         ],
     extras_require = {


### PR DESCRIPTION
## Détails

La version d'Openfisca France utilisée sur ce repository était la 139 alors que la version actuelle d'Openfisca France est la 142.0.1.

Cette PR met à jour la version d'Openfisca France utilisée par ce repository en 142.0.1.
