### PR TITLE
Fix version minimal dépendance openfisca-france

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="4.2.5",
+    version="4.2.6",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers = [
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     install_requires = [
         'OpenFisca-Core >= 35.2.0, < 36',
-        'OpenFisca-France >= 141.0.0, < 143',
+        'OpenFisca-France >= 126, < 143',
         'pandas == 1.0.3'
         ],
     extras_require = {


### PR DESCRIPTION
## Description
Lors de la dernière release ([v4.2.5](https://github.com/openfisca/openfisca-france-local/pull/141)) nous avons mis à jour la dépendance `openfisca-france` et augmenté la version minimale requise sans faire assez de tests.
Cette PR a pour but de corriger ce problème.

## Détails
- La version [126.0.0](https://github.com/openfisca/openfisca-france/releases/tag/126.0.0) d'`openfisca-france` introduit le changement du nom de la variable `cmu_forfait_logement_al` en `css_cmu_forfait_logement_al` que nous utilisons dans la formule de la variable `rennes_metropole_transport`. 
