### PR TITLE
Ajout de l'Action Éducative de Promixité pour l'Eure-et-Loir

### DIFF
--- a/openfisca_france_local/departements/eure_et_loir/aep.py
+++ b/openfisca_france_local/departements/eure_et_loir/aep.py
@@ -1,0 +1,15 @@
+from openfisca_france.model.base import Variable, Menage, MONTH
+
+class eure_et_loir_eligibilite_aep(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "En Eure-et-Loir, éligibilité a l'Action Éducative de Promixité (AEP)"
+    reference = "https://www.eurelien.fr/sites/default/files/media/l_aide_educative_de_proximite.pdf"
+
+    def formula(menage, period):
+        reside_eure_et_loir = menage('eure_et_loir_eligibilite_residence', period)
+        enfants_a_charge = menage.members('enfant_a_charge', period.this_year)
+        has_enfants_a_charge = menage.sum(enfants_a_charge) > 0
+        
+        return reside_eure_et_loir * has_enfants_a_charge

--- a/openfisca_france_local/departements/eure_et_loir/aep.py
+++ b/openfisca_france_local/departements/eure_et_loir/aep.py
@@ -5,7 +5,7 @@ class eure_et_loir_eligibilite_aep(Variable):
     entity = Menage
     definition_period = MONTH
     label = "En Eure-et-Loir, éligibilité a l'Action Éducative de Promixité (AEP)"
-    reference = "https://www.eurelien.fr/sites/default/files/media/l_aide_educative_de_proximite.pdf"
+    reference = "https://eurelien.fr/wp-content/uploads/2023/01/l_aide_educative_de_proximite.pdf"
 
     def formula(menage, period):
         reside_eure_et_loir = menage('eure_et_loir_eligibilite_residence', period)

--- a/tests/departements/eure_et_loir/aep.yml
+++ b/tests/departements/eure_et_loir/aep.yml
@@ -62,6 +62,7 @@
   output:
     eure_et_loir_eligibilite_aep: False
 
+
 - name: Eligibilité à l'aide AEP d'Eure-et-Loir avec menage n'habitant pas en Eure-et-Loir
   period: 2023-01
   input:
@@ -70,10 +71,18 @@
         salaire_imposable: 1000
       parent2:
         salaire_imposable: 0
+      enfant1:
+        age: 8
+        enfant_a_charge:
+          2023: True
+      enfant2:
+        age: 12
+        enfant_a_charge:
+          2023: True
     menage:
       personne_de_reference: parent1
       conjoint: parent2
-      enfants: []
+      enfants: [ "enfant1", "enfant2" ]
       depcom: 45000
   output:
     eure_et_loir_eligibilite_aep: False

--- a/tests/departements/eure_et_loir/aep.yml
+++ b/tests/departements/eure_et_loir/aep.yml
@@ -1,0 +1,79 @@
+- name: Eligibilité à l'aide AEP d'Eure-et-Loir avec menage ayant des enfants à charge
+  period: 2023-01
+  input:
+    individus:
+      parent1:
+        salaire_imposable: 1000
+      parent2:
+        salaire_imposable: 0
+      enfant1:
+        age: 8
+        enfant_a_charge:
+          2023: True
+      enfant2:
+        age: 12
+        enfant_a_charge:
+          2023: True
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [ "enfant1", "enfant2" ]
+      depcom: 28000
+  output:
+    eure_et_loir_eligibilite_aep: True
+
+- name: Eligibilité à l'aide AEP d'Eure-et-Loir avec menage n'ayant pas d'enfants à charge
+  period: 2023-01
+  input:
+    individus:
+      parent1:
+        salaire_imposable: 1000
+      parent2:
+        salaire_imposable: 0
+      enfant1:
+        age: 8
+        enfant_a_charge:
+          2023: False
+      enfant2:
+        age: 12
+        enfant_a_charge:
+          2023: False
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [ "enfant1", "enfant2" ]
+      depcom: 28000
+  output:
+    eure_et_loir_eligibilite_aep: False
+
+- name: Eligibilité à l'aide AEP d'Eure-et-Loir avec menage n'ayant pas d'enfants
+  period: 2023-01
+  input:
+    individus:
+      parent1:
+        salaire_imposable: 1000
+      parent2:
+        salaire_imposable: 0
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: []
+      depcom: 28000
+  output:
+    eure_et_loir_eligibilite_aep: False
+
+- name: Eligibilité à l'aide AEP d'Eure-et-Loir avec menage n'habitant pas en Eure-et-Loir
+  period: 2023-01
+  input:
+    individus:
+      parent1:
+        salaire_imposable: 1000
+      parent2:
+        salaire_imposable: 0
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: []
+      depcom: 45000
+  output:
+    eure_et_loir_eligibilite_aep: False


### PR DESCRIPTION
### Ajout de l'aide d'Action Éducative de Promixité (AEP) pour l'Eure-et-Loir

Collaborateur Atos, je prends la suite de l'activité de Cecile IAEGI (qui avait contribué sur la période 2020-2021) dans le cadre de notre collaboration avec le CD28.

Les conditions d'attribution de l'aide AEP sont les suivantes :
- Résider en Eure-et-Loir
- Avoir au moins un enfant à charge