### PR TITLE
Corrige le calcule du quotient familial sur la réforme dynamique et Corrige les version minimales des dépendances

### DIFF
--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -68,7 +68,7 @@ def is_quotient_familial_eligible(individu: Population, period: Period, conditio
 
     rfr = individu.foyer_fiscal('rfr', period.this_year)
     nbptr = individu.foyer_fiscal('nbptr', period.this_year)
-    quotient_familial = rfr / nbptr
+    quotient_familial = rfr / 12 / nbptr
 
     comparison = operations[condition['operator']]
 
@@ -291,7 +291,6 @@ def generate_variable(benefit: dict):
             conditions_generales_tests, individu, period)
 
         return compute_value(general_eligibilities * is_profile_eligible)
-
 
     return type(benefit['slug'], (Variable,), {
         "value_type": value_type,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="4.2.9",
+    version="4.2.10",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers = [
@@ -23,8 +23,8 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires = [
-        'OpenFisca-Core >= 35.2.0, < 36',
-        'OpenFisca-France >= 126, < 143',
+        'OpenFisca-Core >= 35.8.0, < 36',
+        'OpenFisca-France >= 139.0.0, < 143',
         'pandas == 1.0.3'
         ],
     extras_require = {

--- a/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
+++ b/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
@@ -69,9 +69,9 @@
     age:  [18, 18]
     depcom: ["38120", "38120"]
     rfr:
-      2022: [800, 801]
+      2022: ["9600", "9612"]
     nbptr:
-      2022: [1, 1]
+      2022: ["1", "1"]
   output:
     test_condition_quotient_familial: [200, 0]
 


### PR DESCRIPTION
# Description
---
- Corrige l'erreur de calcul du quotient familiale introduit par la [PR 137](https://github.com/openfisca/openfisca-france-local/pull/137)
- Corrige l'erreur sur le numéro de version minimal des dépendances d'openfisca introduit par inatention lors d'un rebase dans la [PR 130](https://github.com/openfisca/openfisca-france-local/pull/130)