### PR TITLE
Réforme - dynamique : Ajoute la gestion de la périodicité à la condition `quotient_familial`

### DIFF
--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -66,9 +66,11 @@ def is_regime_securite_sociale_eligible(individu: Population, period: Period, co
 
 def is_quotient_familial_eligible(individu: Population, period: Period, condition) -> np.array:
 
+    period_divider = 12 if condition["period"] == 'month' else 1
     rfr = individu.foyer_fiscal('rfr', period.this_year)
     nbptr = individu.foyer_fiscal('nbptr', period.this_year)
-    quotient_familial = rfr / 12 / nbptr
+
+    quotient_familial = rfr / period_divider / nbptr
 
     comparison = operations[condition['operator']]
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="4.4.0",
+    version="4.4.1",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers=[

--- a/test_data/benefits/test_condition_quotient_familial.yaml
+++ b/test_data/benefits/test_condition_quotient_familial.yaml
@@ -1,18 +1,9 @@
 label: Aide au BAFA pour une session de formation générale et d'approfondissement
 conditions_generales:
-  - type: age
-    operator: ">="
-    value: 16
-  - type: age
-    operator: <=
-    value: 25
   - type: quotient_familial
     value: 800
     operator: "<="
     period: month
-  - type: departements
-    values:
-      - "38"
 profils: []
 type: float
 unit: €

--- a/test_data/benefits/test_condition_quotient_familial_year.yaml
+++ b/test_data/benefits/test_condition_quotient_familial_year.yaml
@@ -1,0 +1,11 @@
+label: Aide au BAFA pour une session de formation générale et d'approfondissement
+conditions_generales:
+  - type: quotient_familial
+    value: 9600
+    operator: "<="
+    period: year
+profils: []
+type: float
+unit: €
+periodicite: ponctuelle
+montant: 200

--- a/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
+++ b/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
@@ -62,7 +62,8 @@
   output:
     test_condition_regime_securite_sociale: [286, 0]
 
-- period: 2022-11
+- name: "Test condition <quotient_familial> pour deux périodes : Mensuelle et annuelle"
+  period: 2022-11
   reforms:
   - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
   input:
@@ -74,6 +75,7 @@
       2022: ["1", "1"]
   output:
     test_condition_quotient_familial: [200, 0]
+    test_condition_quotient_familial_year: [200, 0]
 
 - period: 2022-01
   reforms:

--- a/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
+++ b/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
@@ -67,8 +67,6 @@
   reforms:
   - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
   input:
-    age:  [18, 18]
-    depcom: ["38120", "38120"]
     rfr:
       2022: ["9600", "9612"]
     nbptr:


### PR DESCRIPTION
# Description : 
Le calcule d'éligibilité au quotient familial ne s'adapte pas à la `period` décrite dans le fichier d'aide YAML.
# Conséquences : 
Une aide ayant comme critère d'éligibilité un **quotient familial annuel supérieur à** `9600` sera évalué par comparaison à `9600 \ 12`
# Notes : 
Supprime des conditions inutiles dans le fichier de test `test_condition_quotient_familial.yaml`
