### PR TITLE
Utilisation de openfisca-core 38.0.2 

### DIFF
--- a/openfisca_france_local/departements/eure_et_loir/adefip.py
+++ b/openfisca_france_local/departements/eure_et_loir/adefip.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from openfisca_core import parameters
+from openfisca_core.periods import Period
+
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 from numpy.core.defchararray import startswith
@@ -48,7 +50,7 @@ class adefip_eligibilite(Variable):
     definition_period = MONTH
 
     def formula(individu, period):
-        annee_glissante = period.start.period('year').offset(-1)
+        annee_glissante = Period(('year', period.start, 1)).offset(-1)
 
         # conditions de domiciliation
         residence_eure_loire = individu.menage('eure_loire_eligibilite_residence', period)

--- a/openfisca_france_local/metropoles/rennes/mon_aide.py
+++ b/openfisca_france_local/metropoles/rennes/mon_aide.py
@@ -2,6 +2,8 @@ from __future__ import division
 
 from numpy import (maximum as max_, logical_not as not_, absolute as abs_, minimum as min_, select, where, logical_or as or_, round as round_)
 
+from openfisca_core.periods import Period
+
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 from openfisca_france_local.metropoles.rennes.communes import communes
@@ -39,7 +41,7 @@ class rennes_metropole_transport_base_ressource(Variable):
             return (revenus_auto_entrepreneur + rpns_micro_entreprise_benefice + rpns_benefice_exploitant_agricole + rpns_autres_revenus) * (3 / 12)
 
         #on prend en compte le salaire du conjoint
-        last_year = period.start.period('year').offset(-1)
+        last_year = Period(('year', period.start, 1)).offset(-1)
 
         ressources_individuelles_annuelles = (
             individu('aah', last_year, options = [ADD])

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires = [
-        'OpenFisca-Core >= 35.2.0, < 36',
+        'OpenFisca-Core >= 38.0.2, < 38.0.3',
         'OpenFisca-France >= 111.1, < 121',
         'pandas == 1.0.3'
         ],


### PR DESCRIPTION
Modifications apportées afin d'utiliser la version 38.0.2 d'openfisca-core pour être en phase avec openfisca-france.