### PR TITLE
Transforme l'acces aux conditions des aides de la reforme dynamique en parametres

### DIFF
--- a/openfisca_france_local/convert_benefit_conditions_to_parameters.py
+++ b/openfisca_france_local/convert_benefit_conditions_to_parameters.py
@@ -1,0 +1,150 @@
+from openfisca_france.model.base import ParameterNode
+
+
+def condition_to_parameter_data(condition: dict) -> dict:
+    def generate_age_parameter_data(condition: dict) -> dict:
+        parameter_operator: str = comparison_operators[condition['operator']]
+        return {
+            condition_type: {
+                parameter_operator: {
+                    'values': {openfisca_parameter_date: {
+                        'value': condition['value']}},
+                    }
+                }
+            }
+
+    def generate_quotient_familial_parameter_data(condition: dict) -> dict:
+        parameter_operator: str = comparison_operators[condition['operator']]
+        return {
+            condition_type: {
+                condition['period']: {
+                    parameter_operator: {
+                        'values': {openfisca_parameter_date: {
+                            'value': condition['value']
+                            }}
+                        }
+                    }
+                }
+            }
+
+    def generate_regime_securite_sociale_parameter_data(condition: dict) -> dict:
+        def create_regime_data(constraint) -> dict:
+            return {
+                constraint: {
+                    'values': {
+                        openfisca_parameter_date: {'value': condition[constraint]}}
+                    }}
+
+        if 'includes' in condition.keys() and 'excludes' in condition.keys():
+            raise NotImplementedError(
+                'Condition "regime_securite_sociale" does not support having'
+                ' both "includes" and "excludes" properties.\n'
+                'Please check the YAML file.'
+                )
+
+        constraint: str = 'includes' if 'includes' in condition.keys() else 'excludes'
+
+        return {condition_type: create_regime_data(constraint)}
+
+    def generate_common_parameter_data(condition: dict) -> dict:
+        if len(condition) == 1:
+            value = {'value': True}
+        else:
+            value = {'value': condition['values']}
+
+        return {
+            condition_type: {
+                'values': {openfisca_parameter_date: value}
+                }
+            }
+
+    condition_table: dict = {
+        'age': generate_age_parameter_data,
+        'quotient_familial': generate_quotient_familial_parameter_data,
+        'regime_securite_sociale': generate_regime_securite_sociale_parameter_data,
+        }
+
+    openfisca_parameter_date = '2020-01-01'
+
+    comparison_operators = {
+        '<=': 'maximum_inclusif',
+        '>=': 'minimum_inclusif',
+        '<': 'maximum_exclusif',
+        '>': 'minimum_exclusif',
+        }
+
+    condition_type: str = condition['type']
+
+    if condition_type in condition_table:
+        condition_parameter_data = condition_table[condition_type](condition)
+    else:
+        condition_parameter_data = generate_common_parameter_data(condition)
+
+    return condition_parameter_data
+
+
+def conditions_to_node_data(conditions: 'list[dict]') -> dict:
+
+    conditions_formatted = [
+        condition_to_parameter_data(condition)
+        for condition in conditions
+        ]
+
+    data: dict = {'conditions': {}}
+
+    for condition in conditions_formatted:
+        for key in condition:
+            if key in data['conditions']:
+                data['conditions'][key].update(condition[key])
+            else:
+                data['conditions'].update(condition)
+
+    return data
+
+
+def profils_to_node_data(profils: 'list[dict]'):
+    def create_profils_field(data: dict, profil: dict):
+        data['profils'].update({profil['type']: {}})
+
+    def add_profil_with_conditions(data: dict, profil: dict):
+        data['profils'][profil['type']].update(conditions_to_node_data(profil['conditions']))
+
+    def add_boolean_profil(data: dict, profil: dict):
+        date = '2020-01-01'
+        data['profils'][profil['type']] = {date: {'value': True}}
+
+    data: dict = {'profils': {}}
+
+    for profil in profils:
+        create_profils_field(data, profil)
+        if 'conditions' in profil:
+            add_profil_with_conditions(data, profil)
+        else:
+            add_boolean_profil(data, profil)
+
+    return data
+
+
+def generate_amount_parameter_data(montant: dict):
+    date = '2020-01-01'
+
+    return {'montant': {date: {'value': montant}}} if montant else {}
+
+
+def convert_benefit_conditions_to_parameters(benefit: dict) -> ParameterNode:
+    amount_data = generate_amount_parameter_data(benefit.get('montant'))
+
+    conditions_generales = benefit['conditions_generales']
+
+    conditions_generales_data = conditions_to_node_data(conditions_generales)
+
+    node_data: dict = {}
+    node_data.update(conditions_generales_data)
+    node_data.update(amount_data)
+
+    profils: list[dict] = benefit.get('profils')
+    if profils:
+        profils_data = profils_to_node_data(profils)
+        node_data.update(profils_data)
+
+    return ParameterNode(benefit['slug'], data=node_data)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='5.3.1',
+    version='5.3.2',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[

--- a/test_data/benefits/test_condition_age_maximum_exclusif.yaml
+++ b/test_data/benefits/test_condition_age_maximum_exclusif.yaml
@@ -1,12 +1,9 @@
-label: aide conditionee par age
+label: Aide conditionee par un age strictement inférieur à 25 ans
 type: float
 periodicite: ponctuelle
 montant: 106
 conditions_generales:
   - type: age
-    operator: ">="
-    value: 16
-  - type: age
-    operator: "<="
+    operator: <
     value: 25
 profils: []

--- a/test_data/benefits/test_condition_age_minimum_exclusif.yaml
+++ b/test_data/benefits/test_condition_age_minimum_exclusif.yaml
@@ -1,12 +1,9 @@
-label: aide conditionee par age
+label: Aide conditionee par un age strictement inférieur à 25 ans
 type: float
 periodicite: ponctuelle
 montant: 106
 conditions_generales:
   - type: age
-    operator: ">="
-    value: 16
-  - type: age
-    operator: "<="
+    operator: ">"
     value: 25
 profils: []

--- a/test_data/benefits/test_condition_formation_sanitaire_social_et_simples_profils.yaml
+++ b/test_data/benefits/test_condition_formation_sanitaire_social_et_simples_profils.yaml
@@ -1,8 +1,5 @@
 label: bourse sanitaire
 conditions_generales:
-  - type: regions
-    values:
-      - "01"
   - type: formation_sanitaire_social
 profils:
   - type: enseignement_superieur

--- a/test_data/benefits/test_condition_regime_securite_sociale_excludes.yaml
+++ b/test_data/benefits/test_condition_regime_securite_sociale_excludes.yaml
@@ -1,14 +1,8 @@
 label: Aide au Brevet d'Aptitude aux Fonctions de Directeur (BAFD)
 conditions_generales:
-  - type: age
-    operator: ">="
-    value: 18
   - type: regime_securite_sociale
-    includes:
-      - regime_general
-  - type: departements
-    values:
-      - "56"
+    excludes:
+      - regime_agricole
 profils: []
 type: float
 montant: 286

--- a/test_data/benefits/test_condition_regime_securite_sociale_includes.yaml
+++ b/test_data/benefits/test_condition_regime_securite_sociale_includes.yaml
@@ -1,0 +1,8 @@
+label: Aide au Brevet d'Aptitude aux Fonctions de Directeur (BAFD)
+conditions_generales:
+  - type: regime_securite_sociale
+    includes:
+      - regime_general
+profils: []
+type: float
+montant: 286

--- a/test_data/benefits/test_condition_region_corse.yaml
+++ b/test_data/benefits/test_condition_region_corse.yaml
@@ -1,11 +1,5 @@
 label: bourse Animazioni
 conditions_generales:
-  - type: age
-    operator: ">="
-    value: 16
-  - type: age
-    operator: <=
-    value: 30
   - type: regions
     values:
       - "94"

--- a/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
+++ b/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
@@ -56,11 +56,9 @@
   reforms:
   - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
   input:
-    age:  [18, 19]
-    depcom: ["56260", "56260"]
     regime_securite_sociale: [regime_general, regime_agricole]
   output:
-    test_condition_regime_securite_sociale: [286, 0]
+    test_condition_regime_securite_sociale_includes: [286, 0]
 
 - name: "Test condition <quotient_familial> pour deux périodes : Mensuelle et annuelle"
   period: 2022-11
@@ -68,9 +66,9 @@
   - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
   input:
     rfr:
-      2020: ["9600", "9612"]
+      2022: ["9600", "9612"]
     nbptr:
-      2020: ["1", "1"]
+      2022: ["1", "1"]
   output:
     test_condition_quotient_familial: [200, 0]
     test_condition_quotient_familial_year: [200, 0]
@@ -79,7 +77,6 @@
   reforms:
   - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
   input:
-    depcom: ["97105", "97105", "97105", "97105"]
     groupe_specialites_formation: ["groupe_330", "FOrmation non reconnue", "groupe_330", "groupe_330"]
     activite: ["stagiaire", "stagiaire", "chomeur", "etudiant"]
     stagiaire: [true,true,false,false]
@@ -200,7 +197,6 @@
   - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
   input:
     depcom: ["2A004"]
-    age: [18]
   output:
     test_condition_region_corse: [600]
 
@@ -216,8 +212,8 @@
 - period: 2022-11
   name: Condition epcis
   reforms:
-  - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
   - openfisca_france_local.epci_test_factory.epci_reform
+  - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
   input:
     depcom: ["33063", "77002"]
   output:

--- a/tests/reforms/aides_jeunes/test_convert_benefit_conditions_to_parameters.py
+++ b/tests/reforms/aides_jeunes/test_convert_benefit_conditions_to_parameters.py
@@ -1,0 +1,198 @@
+from datetime import date
+import yaml
+import pytest
+from openfisca_france import CountryTaxBenefitSystem
+
+from openfisca_core.parameters import ParameterAtInstant, ParameterNode
+
+
+from openfisca_france_local.convert_benefit_conditions_to_parameters\
+    import convert_benefit_conditions_to_parameters
+
+
+def generate_parameter_in_TBS(parameters: ParameterNode, benefit_path: str):
+    benefit: dict = extract_benefit_file_content(benefit_path)
+
+    new_parameter_node = convert_benefit_conditions_to_parameters(benefit)
+
+    parameters.add_child(new_parameter_node.name, new_parameter_node)
+
+
+@pytest.fixture
+def parameters() -> ParameterNode:
+    return CountryTaxBenefitSystem().parameters
+
+
+@pytest.fixture
+def test_folder() -> str:
+    return 'test_data/benefits/'
+
+
+@pytest.fixture
+def test_condition_age_benefit_path() -> str:
+    return 'test_data/benefits/test_condition_age.yaml'
+
+
+def extract_benefit_file_content(benefit_path: str) -> dict:
+    def _slug_from_Path(path: str):
+        return path.split('/')[-1].replace('-', '_').split('.')[0]
+
+    benefit: dict = yaml.safe_load(open(benefit_path))
+    benefit['slug'] = _slug_from_Path(benefit_path)
+
+    return benefit
+
+
+def test_create_benefit_parameter_node(parameters: ParameterNode, test_condition_age_benefit_path: str):
+    generate_parameter_in_TBS(parameters, test_condition_age_benefit_path)
+
+    assert parameters.test_condition_age.conditions
+
+
+def test_create_age_parameter_node(parameters: ParameterNode, test_condition_age_benefit_path: str):
+    generate_parameter_in_TBS(parameters, test_condition_age_benefit_path)
+
+    assert parameters.test_condition_age.conditions.age
+
+
+def test_create_age_maximum_inclusif_parameter_node(parameters: ParameterNode, test_condition_age_benefit_path: str):
+    generate_parameter_in_TBS(parameters, test_condition_age_benefit_path)
+
+    assert parameters.test_condition_age.conditions.age.maximum_inclusif
+
+
+def test_create_age_maximum_inclusif_parameter_with_value(parameters: ParameterNode, test_condition_age_benefit_path: str):
+    generate_parameter_in_TBS(parameters, test_condition_age_benefit_path)
+
+    assert parameters(str(date.today())).test_condition_age.conditions.age.maximum_inclusif == 25
+
+
+def test_create_both_inclusive_age_parameter_node(parameters: ParameterNode, test_condition_age_benefit_path: str):
+    generate_parameter_in_TBS(parameters, test_condition_age_benefit_path)
+
+    benefit_parameter = parameters(str(date.today())).test_condition_age.conditions
+
+    assert benefit_parameter.age.maximum_inclusif == 25 and \
+        benefit_parameter.age.minimum_inclusif == 16
+
+
+def test_create_age_maximum_exclusif_parameter_node(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_condition_age_maximum_exclusif.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    benefit_parameter = parameters(str(date.today())).test_condition_age_maximum_exclusif.conditions.age.maximum_exclusif
+
+    assert benefit_parameter == 25
+
+
+def test_create_age_minimum_exclusif_parameter_node(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_condition_age_minimum_exclusif.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    benefit_parameter = parameters(str(date.today())).test_condition_age_minimum_exclusif.conditions.age
+
+    assert benefit_parameter.minimum_exclusif == 25
+
+
+def test_create_quotient_familial_parameter(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_condition_quotient_familial.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    at_instant: ParameterAtInstant = parameters("2023-01-01")
+    parameter = at_instant.test_condition_quotient_familial
+
+    assert parameter.conditions.quotient_familial.month.maximum_inclusif == 800
+
+
+def test_create_region_parameter(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_condition_region_corse.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    at_instant: ParameterAtInstant = parameters("2023-01-01")
+    parameter = at_instant.test_condition_region_corse
+
+    assert parameter.conditions.regions == ["94"]
+
+
+def test_create_regime_securite_sociale_includes_parameter(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_condition_regime_securite_sociale_includes.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    at_instant: ParameterAtInstant = parameters("2023-01-01")
+    parameter = at_instant.test_condition_regime_securite_sociale_includes
+
+    assert parameter.conditions.regime_securite_sociale.includes == ["regime_general"]
+
+
+def test_create_regime_securite_sociale_excludes_parameter(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_condition_regime_securite_sociale_excludes.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    at_instant: ParameterAtInstant = parameters("2023-01-01")
+    parameter = at_instant.test_condition_regime_securite_sociale_excludes
+
+    assert parameter.conditions.regime_securite_sociale.excludes == ["regime_agricole"]
+
+
+def test_create_regime_securite_sociale_excludes_and_include_parameter():
+    benefit: dict = {
+        'label': "Aide au Brevet d'Aptitude aux Fonctions de Directeur (BAFD)",
+        'conditions_generales': [{
+            'type': 'regime_securite_sociale',
+            'includes': ['regime_general'],
+            'excludes': ['regime_agricole']
+            }],
+
+        'profils': [],
+        'type': 'float',
+        'montant': 286,
+        'slug': 'test_condition_regime_securite_sociale_excludes_and_includes'
+        }
+
+    with pytest.raises(NotImplementedError):
+        convert_benefit_conditions_to_parameters(benefit)
+
+
+def test_create_formation_sanitaire_social_parameter(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_condition_formation_sanitaire_social_et_simples_profils.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    at_instant: ParameterAtInstant = parameters("2023-01-01")
+    parameter = at_instant.test_condition_formation_sanitaire_social_et_simples_profils
+
+    assert parameter.conditions.formation_sanitaire_social
+
+
+def test_create_empty_profil(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_profil_apprenti.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    at_instant: ParameterAtInstant = parameters("2023-01-01")
+    parameter = at_instant.test_profil_apprenti
+
+    assert parameter.profils.apprenti
+
+
+def test_create_profil_type_only(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_profil_etudiant.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    at_instant: ParameterAtInstant = parameters("2023-01-01")
+    parameter = at_instant.test_profil_etudiant
+
+    assert parameter.profils.etudiant
+
+
+def test_create_amount_106(parameters: ParameterNode, test_condition_age_benefit_path: str):
+    generate_parameter_in_TBS(parameters, test_condition_age_benefit_path)
+
+    at_instant: ParameterAtInstant = parameters("2023-01-01")
+    assert at_instant.test_condition_age.montant == 106
+
+
+def test_create_amount_1000(parameters: ParameterNode, test_folder: str):
+    benefit_path: str = f'{test_folder}test_condition_beneficiaire_rsa.yaml'
+    generate_parameter_in_TBS(parameters, benefit_path)
+
+    at_instant: ParameterAtInstant = parameters("2023-01-01")
+    assert at_instant.test_condition_beneficiaire_rsa.montant == 1000


### PR DESCRIPTION
# Description
Itération sur la réforme `aides-jeunes` qui permet l'interprétation des conditions précisées dans les champs `conditions_generales` et `profils` d'un fichier yaml décrivant une aide simple.
L'idée est de se rapprocher un peu plus de la manière de fonctionner d'openfisca en évitant d'accéder aux valeurs relatives à une aide via l'objet `dict` obtenu en parsant le fichier YAML. À partir de ce `dict` on crée un `ParameterNode` que l'on va ajouter à la racine de l'arbre des paramètres du Tax and Benefits System qu'on utilise.

- Le fichier `convert_benefit_conditions_to_parameters.py` contient la fonction qui prend en entrée un fichier d'aide (YAML) et qui donne un objet `ParameterNode` qui contient les valeurs relatives à l'aide en question dans un langage openfisca.

- Modification de la réforme `aides_jeunes_reform_dynamic` pour inclure la génération et l'inclusion des  `ParameterNode` dans le Tax and Benefits System. 

- Modification de la réforme pour remplacer l'utilisation du dictionnaire par le système de paramètres OpenFisca.

- Ajouts et modifications de tests

- Modification temporaire du script qui imprime les versions minimales des versions d'openfisca pour l'adapter à l'utilisation d'une branche spécifique.

# Explications des modifications apportées au fichier `aides-jeunes-reform.py`

Dans la version précédente, on accède aux valeurs relatives aux aides en lisant un objet `dict` obtenue en parsant les fichiers `yaml`. 
Ces valeurs pouvant être le montant de l'aide ou bien l'age minimum pour être éligible par exemple.

Pour accéder au montant de l'aide on passe d'accéder à la clé "montant" du dictionnaire à l'utilisation des paramètres openfisca qui est bien plus complexe, on manipule des objets `ParameterNodes` qui deviennent des `ParameterAtInstant` une fois qu'on a précisé la période pour laquelle on veut la valeur.

On précise la période avec la syntaxe suivante `parameter(period)`.

On navigue dans l'arbre des paramètres en séparant le nom des nœuds par des `.`, exemple : 
`aide_bafa_rhone_alpe.conditions.age.strictement_inferieur`
Chaque élément séparé par un point est un paramètre qui peut être un nœud ou une feuille.
Si c'est une feuille, c'est alors un objet de type `Parameter`.

## Changements concrets : 
Concrètement, ce changement implique 2 types de modifications pour la réforme `aides_jeunes_reform_dynamic` : 

- La fonction `generate_variable()` et les fonctions de logique sous-jacentes (`build_condition_evaluator_list()` et `build_profil_evaluator()`) ne manipulents plus des `dict` mais des `ParameterNode`.

Ces parties du code étaient simplifiées par le fait que le `dict` envoyé à la fonction `generate_variable()` contenait les informations d'une seule aide.

Maintenant, nous avons un arbre qui contient les informations de toute la législation chargée et nous devons accéder à la branche de l'aide actuellement en cours de traduction.
Cet arbre de `ParameterNode` à une implantation spécifique à **OpenFisca** et isoler les parties qui nous intéresse se fait de manière un peu différente d'un `dict`.

- La fonction `build_condition_evaluator_list()` utilise un tableau de fonction (`condition_table`) dont chaque fonction permet la traduction d'une condition en **OpenFisca**. Ce sont ces conditions qui ont besoin d'accéder aux valeurs stockées dans ces paramètres. 
La manière dont ces paramètres sont stockés a changé et avec elle la manière d'y accéder change aussi.
Il est donc nécessaire de mettre à jour le code qui génère chaque condition.

# Comment tester cette PR
 (la liste n'est pas forcément exhaustive) en plus de la lecture du code: 

- Lancer les tests (après avoir préalablement installé toutes les dépendances et notamment vérifier que la version utilisée d'`openfisca-core` est bien la version `OpenFisca-Core @ git+http://github.com/openfisca/openfisca-core.git@d19af1e834e268d70b09cb92beefbb89bad2c5c1` (et non la version `35.12.0`).

- lancer openfisca avec la commande :
```
openfisca serve --country-package openfisca_france --extensions openfisca_france_local -r openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic openfisca_france_local.epci_test_factory.epci_reform
```
(Pour info, cette commande lance openfisca avec **la législation française**, l'extensions **france-locale**, et les réformes **aides_jeunes_reform_dynamic** et **epci**

S'il y a une erreur, de type `ModuleNotFoundError: No module named 'flask'`
Lancer : `pip install flask flask_cors gunicorn` (ce sont des dépendances nécessaires mais absentes des fichiers de conf, il faut que je fasse un fix)

Le serveur doit se lancer sans erreur

- Vérifier la présence et l'intégrité des paramètres :

Toujours avec le serveur lancé, se rendre sur `http://127.0.0.1:5000/parameters/` et vérifier la présence de paramètres portant les noms des fichiers du dossier `test_data/benefits` (Ce sont des fichiers de tests qui sont sous le formats des fichier d'aides qu'on peut produire avec l'outil de contribution).
Vérifier qu'un fichier comme `test_condition_age_strictement_inferieur.yaml` a bien généré un nœud de paramètre comportant une entrée `conditions.age.strictement_inferieur` avec la valeur `25`.
C'est peut pas évident mais cet exemple est généré par la portion de yaml suivante :
```
conditions_generales:
  - type: age
    operator: ">"
    value: 25
```
Le même fichier produira également une entrée pour le montant de l'aide.



 
