### PR TITLE
Ajoute la gestion des dependances pour installer la serveur api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ clean:
 deps:
 	pip install --upgrade pip build twine
 
+install-web-api:
+	pip install openfisca_core'[web-api]'
+
 install-test:
 	pip install -e ".[test,excel-reader]"
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="5.2.0",
+    version="5.2.1",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers=[


### PR DESCRIPTION
# Description
Pour pouvoir lancer le serveur web avec la commande `openfisca serve --country-package openfisca_france --extensions openfisca_france_local`, les paquets `flask`,`flask_cors`, `gunicorn` sont necessaires.

Voici une proposition qui les ajoute dans le `setup.py` dans un `extra_require` au nom de `web-api`.
Une entrée `install-web-api` est également ajouté dans le makefile pour plus de praticité.