### PR TITLE
Augmente la version minimum d'open-fisca-core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setup(
     packages=find_namespace_packages(),
     include_package_data=True,
     install_requires=[
-        'OpenFisca-Core >= 40, < 41',
-        'OpenFisca-France >= 149.0.0, < 150',
+        'OpenFisca-Core >= 40.0.1, < 41',
+        'OpenFisca-France >= 149.1.1, < 150',
         'pandas >= 1.5.3, <2.0'
         ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="OpenFisca-France-Local",
-    version="5.0.0",
+    version="5.0.1",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers=[


### PR DESCRIPTION
# Description

La version `40.0.0` d'`openfisca-core` utilise `numpy>=1.25`. Cela cause des fuites mémoire sur `openfisca-france`. La version `40.0.1` fixe l'utilisation de `numpy==1.24` qui ne présente pas ce problème.