### PR TITLE
Refactor la gestion de la condition `taux_incapacite` dans la réforme aides jeune

### DIFF
--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -36,21 +36,25 @@ operations = {
     }
 
 
+def compute_operator_condition(eligible_values: ParameterNodeAtInstant, individus_values: np.array) -> np.array:
+    constraints_values = [
+        (operations[constraint], eligible_values[constraint])
+        for constraint in eligible_values
+        ]
+
+    eligibilities = [
+        constraint[0](individus_values, constraint[1])
+        for constraint in constraints_values
+        ]
+
+    return sum(eligibilities) >= len(constraints_values)
+
+
 def is_age_eligible(individu: Population, period: Period, parameters: ParameterNodeAtInstant) -> np.array:
     individus_age = individu('age', period)
     eligible_ages = parameters.age
 
-    age_constraints = [
-        (operations[constraint], eligible_ages[constraint])
-        for constraint in eligible_ages
-        ]
-
-    eligibilities = [
-        constraint[0](individus_age, constraint[1])
-        for constraint in age_constraints
-        ]
-
-    return sum(eligibilities) >= len(age_constraints)
+    return compute_operator_condition(eligible_ages, individus_age)
 
 
 def is_department_eligible(individu: Population, period: Period, parameters: ParameterNodeAtInstant):
@@ -189,17 +193,7 @@ def is_taux_incapacite_eligible(individu: Population, period: Period, parameters
     individus_taux_incapacite = individu('taux_incapacite', period)
     eligible_taux_incapacites = parameters.taux_incapacite
 
-    taux_incapacite_constraints = [
-        (operations[constraint], eligible_taux_incapacites[constraint])
-        for constraint in eligible_taux_incapacites
-        ]
-
-    eligibilities = [
-        constraint[0](individus_taux_incapacite, constraint[1])
-        for constraint in taux_incapacite_constraints
-        ]
-
-    return sum(eligibilities) >= len(taux_incapacite_constraints)
+    return compute_operator_condition(eligible_taux_incapacites, individus_taux_incapacite)
 
 
 def is_chomeur(individu: Population, period: Period) -> np.array:

--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -186,21 +186,20 @@ def is_epci_eligible(individu: Population, period: Period, parameters: Parameter
 
 
 def is_taux_incapacite_eligible(individu: Population, period: Period, parameters: ParameterNodeAtInstant) -> np.array:
-    evaluates = {
-        'inferieur_50': lambda taux: taux < 0.5,
-        'entre_50_et_80': lambda taux: np.logical_and(taux >= 0.5, taux < 0.8),
-        'superieur_ou_egal_80': lambda taux: taux >= 0.8
-        }
+    individus_taux_incapacite = individu('taux_incapacite', period)
+    eligible_taux_incapacites = parameters.taux_incapacite
 
-    taux_incapacite = individu('taux_incapacite', period)
-    elibible_taux = parameters.taux_incapacite
-
-    eligibilities = [
-        evaluates[taux](taux_incapacite)
-        for taux in elibible_taux
+    taux_incapacite_constraints = [
+        (operations[constraint], eligible_taux_incapacites[constraint])
+        for constraint in eligible_taux_incapacites
         ]
 
-    return sum(eligibilities) > 0
+    eligibilities = [
+        constraint[0](individus_taux_incapacite, constraint[1])
+        for constraint in taux_incapacite_constraints
+        ]
+
+    return sum(eligibilities) >= len(taux_incapacite_constraints)
 
 
 def is_chomeur(individu: Population, period: Period) -> np.array:

--- a/openfisca_france_local/convert_benefit_conditions_to_parameters.py
+++ b/openfisca_france_local/convert_benefit_conditions_to_parameters.py
@@ -2,7 +2,7 @@ from openfisca_france.model.base import ParameterNode
 
 
 def condition_to_parameter_data(condition: dict) -> dict:
-    def generate_age_parameter_data(condition: dict) -> dict:
+    def generate_operator_parameter_data(condition: dict) -> dict:
         parameter_operator: str = comparison_operators[condition['operator']]
         return {
             condition_type: {
@@ -59,8 +59,8 @@ def condition_to_parameter_data(condition: dict) -> dict:
             }
 
     condition_table: dict = {
-        'age': generate_age_parameter_data,
-        'taux_incapacite': generate_age_parameter_data,
+        'age': generate_operator_parameter_data,
+        'taux_incapacite': generate_operator_parameter_data,
         'quotient_familial': generate_quotient_familial_parameter_data,
         'regime_securite_sociale': generate_regime_securite_sociale_parameter_data,
         }

--- a/openfisca_france_local/convert_benefit_conditions_to_parameters.py
+++ b/openfisca_france_local/convert_benefit_conditions_to_parameters.py
@@ -60,6 +60,7 @@ def condition_to_parameter_data(condition: dict) -> dict:
 
     condition_table: dict = {
         'age': generate_age_parameter_data,
+        'taux_incapacite': generate_age_parameter_data,
         'quotient_familial': generate_quotient_familial_parameter_data,
         'regime_securite_sociale': generate_regime_securite_sociale_parameter_data,
         }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.0.0',
+    version='6.0.1',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[

--- a/test_data/benefits/test_condition_taux_incapacite.yaml
+++ b/test_data/benefits/test_condition_taux_incapacite.yaml
@@ -4,7 +4,6 @@ profils:
   - type: situation_handicap
     conditions:
       - type: taux_incapacite
-        values:
-          - entre_50_et_80
-          - superieur_ou_egal_80
+        operator: '>='
+        value: 0.5
 type: bool


### PR DESCRIPTION
# Description

La condition `taux_incapacite` peut être gérée de la même façon que la condition `age`.
Voici une proposition pour homogénéiser cette gestion.
