### PR TITLE
Ajoute un fichier CHANGELOG.md

### DIFF
--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .github/*"
+IGNORE_DIFF_ON="README.md CHANGELOG.md CONTRIBUTING.md Makefile .gitignore .github/*"
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 

--- a/.github/is-version-number-acceptable.sh
+++ b/.github/is-version-number-acceptable.sh
@@ -23,3 +23,11 @@ then
     echo "Look at the CONTRIBUTING.md file to learn how the version number should be updated."
     exit 1
 fi
+
+if ! $(dirname "$BASH_SOURCE")/has-functional-changes.sh | grep --quiet CHANGELOG.md
+then
+    echo "CHANGELOG.md has not been modified, while functional changes were made."
+    echo "Explain what you changed before merging this branch into master."
+    echo "Look at the CONTRIBUTING.md file to learn how to write the changelog."
+    exit 2
+fi

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           openfisca test tests --country-package openfisca_france --extensions openfisca_france_local
 
-  check-version:
+  check-version-and-changelog:
     runs-on: ubuntu-20.04
     needs: [ test-yaml ] # Last job to run
     steps:
@@ -86,7 +86,7 @@ jobs:
   check-for-functional-changes:
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
-    needs: [ check-version ]
+    needs: [ check-version-and-changelog ]
     outputs:
       status: ${{ steps.stop-early.outputs.status }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## [6.0.1] - 2023-07-31
+
+_Pour les changements détaillés et les discussions associées, consultez la pull request [#174](https://github.com/openfisca/openfisca-france-local/pull/174)_
+
+### Changed
+
+- Modifie l'implantation du paramètre taux_incapacité dans la réforme dynamique Aides-Jeunes, sans changement des résultats des calculs
+
+## [6.0.0] - 2023-07-24
+
+_Pour les changements détaillés et les discussions associées, consultez la pull request [#173](https://github.com/openfisca/openfisca-france-local/pull/173)_
+
+### Added
+
+- Ajoute la compatibilité avec `OpenFisca-Core` v41.x
+- Ajoute la compatibilité avec `OpenFisca-France` v150.x
+
+### Removed
+
+- **Breaking:** retire la génération de documentation dans l'API Web à la suite de la mise à jour d'`openfisca-Core v41` ([OpenFisca-Core #1189](https://github.com/openfisca/openfisca-core/pull/1189))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,14 @@ Certaines règles sont communes à tous les dépôts OpenFisca et sont détaill�
 
 ## Gestion sémantique de version
 
-Le niveau des évolutions d'OpenFisca-France-Local doivent pouvoir être comprises par des réutilisateurs qui n'interviennent pas nécessairement sur le code. 
+Le niveau des évolutions d'OpenFisca-France-Local doivent pouvoir être comprises par des réutilisateurs qui n'interviennent pas nécessairement sur le code.
 
 Un numéro de version doit donc être attribué à toute évolution intégrée sur la branche principale `master` (par la mise à jour du fichier `setup.py`). Ses règles d'incrémentation suivent les principes du versionnement sémantique détaillés dans [la documentation générale](https://openfisca.org/doc/contribute/semver.html).
+
+## Formalisation du CHANGELOG
+
+Chaque version donne lieu à une description des changements qu'elle apporte dans le fichier `CHANGELOG.md`, fichier qui respecte le standard [Common Changelog](https://common-changelog.org).
+
+La syntaxe à utiliser pour une entrée valide est détaillée dans [le wiki](https://github.com/openfisca/openfisca-france-local/wiki/Ajouter-une-entr%C3%A9e-dans-le-CHANGELOG).
+
+Chaque Pull Request acceptée sur la branche principale déclenche le déploiement d'une nouvelle version.


### PR DESCRIPTION
# Description
De l'avis de différentes personnes de la communauté, la mise en place d'un journal des changements apportés par les différentes release sur `openfisca-france-local` serait bénéfique.

Avec la suggestion de @MattiSG, voici une proposition de mise en œuvre mêlant ce qui se fait déjà sur `openfisca-france` et de la standardisation inspirée de [common changelog](https://common-changelog.org/#22-release).

# Implantation

L'idée générale est de prendre la structure proposée par common changelog et d'y intégrer les éléments pertinents pour parler des évolutions liées au système socio-fiscale sur `openfisca-france-local`.

Concrètement  on se retrouve avec : 
## 1 - le Header Common Changelog personnalisé
Initialement `## <version> - <date>` Si on suit les règles de Common Changelog.
Je propose d'y ajouter la référence de la PR  (Comme ce qui se fait dans `openfisca-france`).
En effet, Common Changelog semble s'adapter à des projets avec des releases conséquentes, rassemblant plusieurs PR et donc les références sont précisés à chaques changements.
Chez nous, en écrasante majorité, **une PR == une release**

## 2 - Optionel [La notice Common Changelog](https://common-changelog.org/#23-notice)
La notice est optionelle est vient remplir plusieurs fonctions.
Il arrive que la release en question necessite une lecture particulière, détaillée à un autre endroit (issues, conversations, poste de blog ou encore un fichier `UPGRADING.md` dont nous n'avons pas encore besoin).
La notice permet de renvoyer le lecteur vers ces informations essentielles.

Elle peut aussi permettre de clarifier une information essentielle, sans faire référence à un document externe.

Vous pouvez voir un exemple pour la version `6.0.0`.

**C'est un paragraphe d'une seule phrase, en _italique_**

## 3 - La qualification des changements d'`openfisca-france`

Les releases dans le changelog d'`openfisca-france` commencent par 4 informations : 
```
- Évolution du système socio-fiscal. | Amélioration technique. | Correction d'un crash. | Changement mineur.
- Périodes concernées : toutes. | jusqu'au JJ/MM/AAAA. | à partir du JJ/MM/AAAA.
- Zones impactées : chemin/vers/le/fichier/contenant/les/variables/impactées.
- Détails
```
Les deux premières me semblent indispensables pour une meilleure compréhension des implications par les profils moins techniques.

**Zones impactées** apporte une synthèse précises des fichiers touchés, je me suis dit que c'était également utile même si dispensable. **Qu'en pensez-vous ?**

**Détails** Cette partie est équivalente aux [Change groups de common-changelog](https://common-changelog.org/#24-change-group). Je propose donc de ne pas l'inclure mais d'utiliser la syntaxe des change groups que je détaille dans la partie suivante.

## 4 - Les changements ([Change groups de common-changelog](https://common-changelog.org/#24-change-group))

L'idée de Common changelog est de présenter les changements par catégories distinctes.
Il existe **4 catégories**:
```
- Changed - for changes in existing functionality
- Added - for new functionality
- Removed - for removed functionality
- Fixed - for bug fixes.
```
Par cohérence avec le reste du projet, je propose de les traduire: 
```
- Changé.es - pour les changements apportés à des fonctionnalités existantes.
- Ajouté.es - Pour les ajouts de nouvelles fonctionnalités
- Retiré.es - Pour le retrait de fonctionnalités
- Corrigé.es - Pour la correction de problèmes
```
-> Merci de me faire des retours là-dessus.

On présente les catégorie avec un titre Markdown de 3ième niveau, et on liste les modifications. Exemple :
```
### Changé

- Met à jour le SMIC avec les valeurs de 2023
- ...
- ...
```

**Les modifications sont triées** : D'abord les **breaking changes** puis par ordre d'importance.

# Détails :

## Les préfixes :

Comme dans le changelog de la version `6.0.0` proposée ici, on peut voir le préfixe **breaking** qui va mettre en avant un changement particulier, ici changement qui entraine une incompatibilité avec les versions antérieures.
C'est le préfixe qui me semble le plus utile, mais Common Changelog documente aussi [d'autres utilités ici](https://common-changelog.org/#244-prefixes)

## Les releases github :

Common changelog recommande de créer des `tags` pour chaque version et de lié ce `tag` à une `release` reprenant le contenu du changelog. Ceci me semble pertinent, à voir là mise en pratique (piste dans la section **automatisation** juste après.

## L'automatisation :

- Il me semble intéressant de reprendre la vérification faite par la CI sur `openfisca-france` qui a pour but de vérifier si le changelog à bien été modifié avant d'accepter la PR.

- Pour la publication des releases, Common CHangelog aborde le sujet de l'automatisation de la chose dans [sa documentation](https://common-changelog.org/#51-github-actions). Il est mentionné l'utilisation d'une [action github](https://common-changelog.org/#51-github-actions) facilitant la chose mais elle n'est pas publiée par github.
-> Qu´en pensez-vous ?


# Conclusion : 
Le but est d'itérer sur cette proposition pour arriver au résultat le plus utile et le moins contraignant possible.

Tout est sujet à discussion, vos avis sont bienvenus.
J'attire cependant votre attention et sollicite vos retours sur les points suivants : 
- Les éléments du changelog d'`openfisca-france` à garde et notamment `Détails`
- La traduction des "changements", faut-il traduire  ? est-ce ma proposition semble acceptable? 
- L'automatisation des releases github va [une action publiée par la communauté](https://github.com/anton-yurchenko/git-release)

