### PR TITLE
Reform_dynamic : Permet de charger le chemin des aides via une variable d'environement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [6.0.3] - 2023-08-17
+
+_Pour les changements détaillés et les discussions associées, consultez la pull request [#177](https://github.com/openfisca/openfisca-france-local/pull/177)_
+
+### Added
+
+- Ajoute la possibilité de spécifier le chemin des aides à charger via la reform_dynamic par une variable d'environnement DYNAMIC_BENEFIT_FOLDER
+
 ## [6.0.2] - 2023-08-16
 
 _Pour les changements détaillés et les discussions associées, consultez la pull request [#171](https://github.com/openfisca/openfisca-france-local/pull/171)_

--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import os
+from os import path, getenv
 
 import collections
 from typing import Union
@@ -379,21 +379,21 @@ def generate_variable(benefit: dict):
 
 
 root = '.'
-path = 'test_data/benefits'
-current_path = os.path.join(root, path)
+benefit_path = 'test_data/benefits'
+current_path = path.join(root, benefit_path)
 
 
 class aides_jeunes_reform_dynamic(reforms.Reform):
     def __init__(self, baseline, benefits_folder_path=current_path):
-        self.benefits_folder_path = benefits_folder_path
+        self.benefits_folder_path = getenv('DYNAMIC_BENEFIT_FOLDER', benefits_folder_path)
         super().__init__(baseline)
 
     def apply(self):
         try:
             benefit_files_paths: 'list[str]' = self._extract_benefits_paths(self.benefits_folder_path)
 
-            for path in benefit_files_paths:
-                benefit: dict = self._extract_benefit_file_content(path)
+            for benefit_path in benefit_files_paths:
+                benefit: dict = self._extract_benefit_file_content(benefit_path)
                 benefit_parameters: ParameterNode = convert_benefit_conditions_to_parameters(benefit)
                 self._add_parameters_into_current_tax_and_benefits_system(benefit_parameters)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.0.2',
+    version='6.0.3',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[


### PR DESCRIPTION
# Description :
Cette proposition ajoute la possibilité de spécifier le chemin des aides à charger via la `reform_dynamic` par une variable d'environnement `DYNAMIC_BENEFIT_FOLDER`.