### PR TITLE
Met à jour openfisca-france en version 151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [6.1.0] - 2023-08-22
+
+Met à jour la dépendance Openfisca-France en version 151
+
+_Pour les changements détaillés et les discussions associées, consultez la pull request [#178](https://github.com/openfisca/openfisca-france-local/pull/178)_
+
 ## [6.0.3] - 2023-08-17
 
 _Pour les changements détaillés et les discussions associées, consultez la pull request [#177](https://github.com/openfisca/openfisca-france-local/pull/177)_

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.0.3',
+    version='6.1.0',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'OpenFisca-Core >= 40.0.1, < 42',
-        'OpenFisca-France >= 149.1.1, < 151',
+        'OpenFisca-France >= 149.1.1, < 152',
         'pandas >= 1.5.3, <2.0'
         ],
     extras_require={


### PR DESCRIPTION
## Détails

Cette PR met à jour Openfisca-france en version 151 suite à la PR https://github.com/openfisca/openfisca-france/pull/2171

Pas de breaking-changes sur openfisca-france-local avec ce changement de version