### PR TITLE
Met à jour la version max d'openfisca à 153

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [6.2.0] - 2023-09-05
+
+_Pour les changements détaillés et les discussions associées, consultez la pull request [#144](https://github.com/openfisca/openfisca-france-local/pull/144)_
+
 ## [6.1.0] - 2023-08-22
 
 _Pour les changements détaillés et les discussions associées, consultez la pull request [#178](https://github.com/openfisca/openfisca-france-local/pull/178)_

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.1.1',
+    version='6.2.0',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'OpenFisca-Core >= 40.0.1, < 42',
-        'OpenFisca-France >= 149.1.1, < 152',
+        'OpenFisca-France >= 149.1.1, < 154',
         'pandas >= 1.5.3, <2.0'
         ],
     extras_require={


### PR DESCRIPTION
Cette PR met à jour la version max d'openfisca-france à 153 cf [PR openfisca-france]( https://github.com/openfisca/openfisca-france/pull/2177) 