### PR TITLE
Corrige les problemes de profils manquant et de profils beneficiaire_rsa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## [6.3.0] - 2023-09-11
+## [6.4.0] - 2023-09-18
+
+_Pour les changements détaillés et les discussions associées, consultez la pull request [#182](https://github.com/openfisca/openfisca-france-local/pull/182)_
+
+### Added
+
+- Ajoute le profil `beneficiaire_rsa`
+
+### Fixed
+
+- Corrige le crash dans le cas où le fichier d'aide ne contient pas la clé `profils`
+
+## [6.3.0] - 2023-09-18
 
 _Pour les changements détaillés et les discussions associées, consultez la pull request [#181](https://github.com/openfisca/openfisca-france-local/pull/181)_
 

--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -133,7 +133,7 @@ def is_formation_sanitaire_social_eligible(individu: Population, period: Period,
     return id_formation_groupe == id_formation_sanitaire_social
 
 
-def is_beneficiaire_rsa_eligible(individu: Population, period: Period, _) -> np.array:
+def is_beneficiaire_rsa_eligible(individu: Population, period: Period, _ = None) -> np.array:
     rsa = individu.famille('rsa', period)
 
     return rsa > 0
@@ -272,6 +272,7 @@ profil_table = {
     'service_civique': is_actif,
     'inactif': is_inactif,
     'situation_handicap': is_situation_handicap,
+    'beneficiaire_rsa': is_beneficiaire_rsa_eligible,
     }
 
 

--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -345,7 +345,7 @@ def generate_variable(benefit: dict):
 
     eligible_profiles_tests = [
         build_profil_evaluator(profil)
-        for profil in benefit['profils']
+        for profil in benefit.get('profils', [])
         ]
 
     def compute_amount(eligibilities: np.array):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.3.0',
+    version='6.4.0',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[

--- a/test_data/benefits/test_pas_de_profile.yaml
+++ b/test_data/benefits/test_pas_de_profile.yaml
@@ -1,0 +1,9 @@
+label: Aide sans champs profils
+type: float
+periodicite: ponctuelle
+montant: 106
+conditions_generales:
+  - type: age
+    operator: <
+    value: 25
+

--- a/test_data/benefits/test_profil_beneficiaire_rsa.yaml
+++ b/test_data/benefits/test_profil_beneficiaire_rsa.yaml
@@ -1,0 +1,12 @@
+label: Aide au permis de conduire
+institution: intercommunalite_toulon_provence_mediterranee
+prefix: l’
+conditions_generales:
+  - type: regions
+    values:
+      - "11"
+profils:
+  - type: beneficiaire_rsa
+    conditions: []
+type: float
+montant: 450

--- a/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
+++ b/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
@@ -237,3 +237,17 @@
     taux_incapacite: [0.5, 0.49, 0.8]
   output:
     test_condition_taux_incapacite: [1, 0,1]
+
+- period: 2022-11
+  name: Profil beneficiaire RSA
+  reforms:
+  - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
+  output:
+    test_profil_beneficiaire_rsa: 0
+
+- period: 2022-11
+  name: Test fichier d'aide profils
+  reforms:
+  - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
+  output:
+    test_pas_de_profile: 0


### PR DESCRIPTION
## [6.3.0] - 2023-09-15

_Pour les changements détaillés et les discussions associées, consultez la pull request [#182](https://github.com/openfisca/openfisca-france-local/pull/182)_

### Added

- Ajoute le profil `beneficiaire_rsa`

### Fixed

- Corrige le crash dans le cas où le fichier d'aide ne contient pas la clé `profils`