### PR TITLE
Ajoute l'aide 100 repas gratuits pour les étudiants boursiers échelons 3 à 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [6.5.0] - 2023-09-22
+
+_Pour les changements détaillés et les discussions associées, consultez la pull request [#184](https://github.com/openfisca/openfisca-france-local/pull/184)_
+
+### Added
+
+- Ajoute la variable `crous_aide_100_repas_gratuits`
+
 ## [6.4.1] - 2023-09-19
 
 _Pour les changements détaillés et les discussions associées, consultez la pull request [#183](https://github.com/openfisca/openfisca-france-local/pull/183)_

--- a/openfisca_france_local/parameters/regions/hauts_de_france/crous/aide_100_repas_gratuits.yml
+++ b/openfisca_france_local/parameters/regions/hauts_de_france/crous/aide_100_repas_gratuits.yml
@@ -1,0 +1,19 @@
+age:
+  description: Limite d'âge de l'aide du crous et de la région Hauts-de-France de 100 repas gratuits aux étudiants boursiers
+  maximum:
+    2023-09-01:
+      value: 35
+
+echelon_boursier:
+  description: Echelons autorisés pour l'aide du crous et de la région Hauts-de-France de 100 repas gratuits aux étudiants boursiers 
+  minimum:
+    2023-09-01:
+      value: 3
+  maximum:
+    2023-09-01:
+      value: 7
+
+metadata:
+  reference:
+    2023-09-01:
+      href: https://www.ij-hdf.fr/actualite/747/100-repas-gratuits-de-nouveau-attribues-aux-etudiants-boursiers-echelon-3-a-7#:~:text=Le%20Conseil%20R%C3%A9gional%20Hauts-de,en%20restos

--- a/openfisca_france_local/regions/hauts_de_france/crous/aide_100_repas_gratuits.py
+++ b/openfisca_france_local/regions/hauts_de_france/crous/aide_100_repas_gratuits.py
@@ -1,0 +1,40 @@
+from numpy.core.defchararray import startswith
+from openfisca_france.model.prestations.education import TypesScolarite, TypesClasse
+from openfisca_france.model.base import Individu, MONTH, not_, Variable
+
+code_departements = [b'59', b'62']
+
+class crous_aide_100_repas_gratuits(Variable):
+    value_type = float
+    entity = Individu
+    label = "Éligibilité financière à l'aide du crous et de la région Hauts-de-France de 100 repas gratuits aux étudiants boursiers échelon 3 à 7"
+    reference = "https://www.ij-hdf.fr/actualite/747/100-repas-gratuits-de-nouveau-attribues-aux-etudiants-boursiers-echelon-3-a-7#:~:text=Le%20Conseil%20R%C3%A9gional%20Hauts-de,en%20restos"
+    definition_period = MONTH
+
+    def formula(individu, period, parameters):
+        params = parameters(period).regions.hauts_de_france.crous.aide_100_repas_gratuits
+
+        age = individu('age', period)
+        handicap = individu('handicap', period)
+        depcom = individu.menage('depcom', period)
+        anne_etude = individu('annee_etude', period)
+        echelon_boursier = individu('bourse_criteres_sociaux_echelon', period)
+
+        
+        eligibilite_geographique = sum([startswith(depcom, code_departement) for code_departement in code_departements])
+
+        # Sont éligibles les étudiants ayant moins de 35 ans (limite d’âge non applicable aux étudiants en situation de handicap)
+        eligibilite_age = not_(handicap) * (age <= params.age.maximum) + handicap
+
+        # Sont éligibles les personnes inscrites dans un établissement d’enseignement supérieur, public ou privé, partenaire de la Région, reconnu par le ministère de l’Enseignement supérieur, 
+        # de la recherche et de l’innovation sur le territoire des Hauts-de-France, ou inscrites dans un établissement dispensant une formation sanitaire ou sociale gérée par la Région.
+        eligibilite_scolarite = (individu('scolarite', period) == TypesScolarite.enseignement_superieur) # + (individu('scolarite', period) == TypesScolarite.formation_sanitaire_ou_sociale) @Todo : Ajouter la variable 'formation_sanitaire_ou_sociale' sur sur openfisca-france ? 
+
+        # Sont éligibles les étudiants inscrits en BTS sont exclus de ce dispositif ainsi que tous les étudiants dont l’établissement d’inscription est un lycée, tels que les étudiants en CPGE. 
+        eligibilite_annee_etude = (anne_etude != TypesClasse.cpge_1) * (anne_etude != TypesClasse.bts_1) * (anne_etude != TypesClasse.bts_2) * (anne_etude != TypesClasse.cpge_2)
+
+        # Sont éligibles les étudiants boursiers échelon 3 à 7
+        eligiblite_echelon_boursier = (echelon_boursier >= params.echelon_boursier.minimum ) * (echelon_boursier <= params.echelon_boursier.maximum)
+
+        return eligibilite_geographique * eligibilite_age * eligibilite_scolarite * eligibilite_annee_etude * eligiblite_echelon_boursier
+ 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.4.1',
+    version='6.5.0',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[

--- a/tests/regions/hauts-de-france/crous/aide_100_repas_gratuits.yml
+++ b/tests/regions/hauts-de-france/crous/aide_100_repas_gratuits.yml
@@ -1,0 +1,44 @@
+
+- name: Égibilité de l'aide du crous et de la région Hauts-de-France de 100 repas gratuits aux étudiants boursiers échelon 3 à 7
+  period: 2023-09
+  input:
+    depcom: [59000, 59000, 59000, 59000, 59000, 59000]
+    age: [22, 22, 22, 22, 22, 22]
+    scolarite: ["enseignement_superieur", "enseignement_superieur", "enseignement_superieur", "enseignement_superieur", "enseignement_superieur", "enseignement_superieur"]
+    bourse_criteres_sociaux_echelon: [0, 1, 2, 3, 5, 7]
+  output:
+    crous_aide_100_repas_gratuits: [false, false, false, true, true, true]
+
+- name: Égibilité de l'aide du crous et de la région Hauts-de-France de 100 repas gratuits aux étudiants boursiers échelon 3 à 7 en fonction de l'âge et de la situation géographique
+  period: 2023-09
+  input:
+    depcom: [59000, 59000, 59000, 68000]
+    age: [15, 30, 36, 30]
+    scolarite: ["enseignement_superieur", "enseignement_superieur", "enseignement_superieur", "enseignement_superieur"]
+    bourse_criteres_sociaux_echelon: [3, 3, 3, 3]
+  output:
+    crous_aide_100_repas_gratuits: [true, true, false, false]
+
+- name: Égibilité de l'aide du crous et de la région Hauts-de-France de 100 repas gratuits aux étudiants boursiers échelon 3 à 7 en fonction de la situation d'handicap
+  period: 2023-09
+  input:
+    depcom: [59000, 59000]
+    age: [38, 38]
+    scolarite: ["enseignement_superieur", "enseignement_superieur"]
+    handicap: [true, false]
+    bourse_criteres_sociaux_echelon: [3, 3]
+  output:
+    crous_aide_100_repas_gratuits: [true, false]
+
+- name: Égibilité de l'aide du crous et de la région Hauts-de-France de 100 repas gratuits aux étudiants boursiers échelon 3 à 7 en fonction de la scolarité et de l'année d'étude
+  period: 2023-09
+  input:
+    depcom: [59000, 59000, 59000, 59000, 59000, 59000]
+    age: [22, 22, 22, 22, 22, 22]
+    scolarite: ["enseignement_superieur", "lycee", "enseignement_superieur", "enseignement_superieur", "enseignement_superieur", "enseignement_superieur"]
+    annee_etude: [licence_1, seconde, bts_1, bts_2, cpge_1, cpge_2]
+    bourse_criteres_sociaux_echelon: [3, 3, 3, 3, 3, 3]
+  output:
+    crous_aide_100_repas_gratuits: [true, false, false, false, false, false]
+
+


### PR DESCRIPTION
## [6.5.0] - 2023-09-22

_Pour les changements détaillés et les discussions associées, consultez la pull request [#184](https://github.com/openfisca/openfisca-france-local/pull/184)_

### Added

- Ajoute la variable `crous_aide_100_repas_gratuits`

### Questionnement : ajouter le type de scolarité "formation_sanitaire_ou_sociale" dans Openfisca-france (condition supplémentaire possible pour cette aide?)