### PR TITLE
Corrige warning `deprecated path()` dans la réforme `epci_test_factory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## [6.7.1] - 2023-11-15
+
+_Pour les changements détaillés et les discussions associées, référencez la pull request [#190](https://github.com/openfisca/openfisca-france-local/pull/190)
+
+### Fixed
+
+- Corrige le warning lié à l'utilisation de `ressource.path()` dans la réforme `epci_test_factory`
 
 ## [6.7.0] - 2023-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [6.7.1] - 2023-11-15
+## [6.7.1] - 2023-11-21
 
 _Pour les changements détaillés et les discussions associées, référencez la pull request [#190](https://github.com/openfisca/openfisca-france-local/pull/190)
 

--- a/openfisca_france_local/epci_test_factory.py
+++ b/openfisca_france_local/epci_test_factory.py
@@ -3,7 +3,6 @@ from openfisca_france.model.base import Variable, Menage, MONTH
 from openfisca_core import reforms
 
 import pandas as pd
-from importlib import resources
 
 
 def epci_test_factory(groups, code):
@@ -27,10 +26,9 @@ def epci_test_factory(groups, code):
 
 class epci_reform(reforms.Reform):
     def apply(self):
-        with resources.path('openfisca_france_local', 'epcicom2020.xlsx') as filepath:
-            raw = pd.read_excel(filepath)
-            raw.insee = raw.insee.astype('|S5')
-            df = raw[['siren', 'insee', 'raison_sociale']].groupby('siren')
+        raw = pd.read_excel('openfisca_france_local/epcicom2020.xlsx')
+        raw.insee = raw.insee.astype('|S5')
+        df = raw[['siren', 'insee', 'raison_sociale']].groupby('siren')
 
-            for siren in df.groups:
-                self.add_variable(epci_test_factory(df, siren))
+        for siren in df.groups:
+            self.add_variable(epci_test_factory(df, siren))

--- a/openfisca_france_local/epci_test_factory.py
+++ b/openfisca_france_local/epci_test_factory.py
@@ -6,31 +6,32 @@ from numpy.core.defchararray import startswith
 import pandas as pd
 from importlib import resources
 
+
 def epci_test_factory(groups, code):
-  group = groups.get_group(code)
-  code_communes = group['insee'].values
-  raison_sociale =  group['raison_sociale'].values[0]
+    group = groups.get_group(code)
+    code_communes = group['insee'].values
+    raison_sociale = group['raison_sociale'].values[0]
 
-  class NewEPCITestClass(Variable):
-      value_type = bool
-      entity = Menage
-      definition_period = MONTH
-      label = u"Ménage dans une commune de l'EPCI %s" % raison_sociale
+    class NewEPCITestClass(Variable):
+        value_type = bool
+        entity = Menage
+        definition_period = MONTH
+        label = u"Ménage dans une commune de l'EPCI %s" % raison_sociale
 
-      def formula(menage, period):
-          depcom = menage('depcom', period)
-          return sum([depcom == code for code in code_communes])
+        def formula(menage, period):
+            depcom = menage('depcom', period)
+            return sum([depcom == code for code in code_communes])
 
-  NewEPCITestClass.__name__ = "menage_dans_epci_siren_%i" % code
-  return NewEPCITestClass
+    NewEPCITestClass.__name__ = "menage_dans_epci_siren_%i" % code
+    return NewEPCITestClass
 
 
 class epci_reform(reforms.Reform):
     def apply(self):
-      with resources.path('openfisca_france_local', 'epcicom2020.xlsx') as filepath:
-        raw = pd.read_excel(filepath)
-        raw.insee = raw.insee.astype('|S5')
-        df = raw[['siren', 'insee', 'raison_sociale']].groupby('siren')
+        with resources.path('openfisca_france_local', 'epcicom2020.xlsx') as filepath:
+            raw = pd.read_excel(filepath)
+            raw.insee = raw.insee.astype('|S5')
+            df = raw[['siren', 'insee', 'raison_sociale']].groupby('siren')
 
-        for siren in df.groups:
-          self.add_variable(epci_test_factory(df, siren))
+            for siren in df.groups:
+                self.add_variable(epci_test_factory(df, siren))

--- a/openfisca_france_local/epci_test_factory.py
+++ b/openfisca_france_local/epci_test_factory.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from openfisca_france.model.base import Variable, Menage, MONTH
 from openfisca_core import reforms
-from numpy.core.defchararray import startswith
 
 import pandas as pd
 from importlib import resources

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.7.0',
+    version='6.7.1',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[
@@ -33,7 +33,6 @@ setup(
             'nose',
             ],
         'excel-reader': [
-            'xlrd == 1.2.0',
             'openpyxl == 3.1.2',
             ]
         },


### PR DESCRIPTION
### Fixed

- Corrige le warning lié à l'utilisation de `ressource.path()` dans la réforme `epci_test_factory`