### PR TITLE
Reform dynamique : ajoute la gestion de la condition `attached_to_institution`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## [6.8.0] - 2023-11-22
+
+_Pour les changements détaillés et les discussions associées, référencez la pull request [#191](https://github.com/openfisca/openfisca-france-local/pull/191)
+
+### Added
+
+- Ajoute la gestion de la condition attaches_to_institution dans la `aides_jeunes_reform_dynamic`
 
 ## [6.7.2] - 2023-11-23
 

--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -237,10 +237,6 @@ def is_situation_handicap(individu: Population, period: Period) -> np.array:
     return individu('handicap', period)
 
 
-def not_implemented_condition(_: Population, __: Period, condition: ParameterNodeAtInstant) -> np.array:
-    raise NotImplementedError(f'Condition in `{condition.name}` is not implemented')
-
-
 condition_table = {
     'age': is_age_eligible,
     'regions': is_region_eligible,
@@ -255,7 +251,6 @@ condition_table = {
     'communes': is_commune_eligible,
     'epcis': is_epci_eligible,
     'taux_incapacite': is_taux_incapacite_eligible,
-    'attached_to_institution': not_implemented_condition,
     }
 
 
@@ -295,7 +290,7 @@ def build_condition_evaluator_list(conditions: 'list[dict]') -> 'list[ConditionE
             for condition in conditions
             ]
     except KeyError as e:
-        raise KeyError(f"Condition `{(e.args[0])}` is unknown.")
+        raise NotImplementedError(f"Condition `{(e.args[0])}` is unknown.")
 
     return evaluators
 
@@ -304,7 +299,7 @@ def build_profil_evaluator(profil: dict) -> ProfileEvaluator:
     try:
         predicate = profil_table[profil['type']]
     except KeyError:
-        raise KeyError(f"Profil `{profil['type']}` is unknown.")
+        raise NotImplementedError(f"Profil `{profil['type']}` is unknown.")
 
     conditions = profil.get('conditions', [])
 

--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -438,9 +438,10 @@ class aides_jeunes_reform_dynamic(reforms.Reform):
         def _slug_from_path(path: str):
             return path.split('/')[-1].replace('-', '_').split('.')[0]
 
-        benefit: dict = yaml.safe_load(open(benefit_path))
-        benefit['slug'] = _slug_from_path(benefit_path)
-        benefit = _convert_institution_to_condition(benefit)
+        with open(benefit_path) as file:
+            benefit: dict = yaml.safe_load(file)
+            benefit['slug'] = _slug_from_path(benefit_path)
+            benefit = _convert_institution_to_condition(benefit)
         return benefit
 
     def _extract_paths(self, folder: str) -> 'list[str]':

--- a/openfisca_france_local/aides_jeunes_reform.py
+++ b/openfisca_france_local/aides_jeunes_reform.py
@@ -374,14 +374,12 @@ def generate_variable(benefit: dict):
         })
 
 
-root = '.'
-benefit_path = 'test_data/benefits'
-institutions_path = 'test_data/institutions'
-current_path = path.join(root, benefit_path)
+default_benefit_path = 'test_data/benefits'
+default_institutions_path = 'test_data/institutions'
 
 
 class aides_jeunes_reform_dynamic(reforms.Reform):
-    def __init__(self, baseline, benefits_folder_path=current_path, institutions_folder_path=institutions_path):
+    def __init__(self, baseline, benefits_folder_path=default_benefit_path, institutions_folder_path=default_institutions_path):
         self.benefits_folder_path = getenv('DYNAMIC_BENEFIT_FOLDER', benefits_folder_path)
         self.institutions_folder_path = getenv('DYNAMIC_INSTITUTION_FOLDER', institutions_folder_path)
         super().__init__(baseline)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.7.2',
+    version='6.8.0',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[

--- a/test_data/benefits/test_condition_attached_to_institution_caf.yaml
+++ b/test_data/benefits/test_condition_attached_to_institution_caf.yaml
@@ -1,0 +1,10 @@
+label: Test condition attached_to_institutions caf
+institution: institution_caf
+prefix: l’
+conditions_generales:
+  - type: attached_to_institution
+type: float
+unit: €
+periodicite: mensuelle
+montant: 19
+floorAt: 1

--- a/test_data/benefits/test_condition_attached_to_institution_communes.yaml
+++ b/test_data/benefits/test_condition_attached_to_institution_communes.yaml
@@ -1,0 +1,10 @@
+label: Test condition attached_to_institutions communes
+institution: institution_commune
+prefix: l’
+conditions_generales:
+  - type: attached_to_institution
+type: float
+unit: €
+periodicite: mensuelle
+montant: 16.8
+floorAt: 1

--- a/test_data/benefits/test_condition_attached_to_institution_departements.yaml
+++ b/test_data/benefits/test_condition_attached_to_institution_departements.yaml
@@ -1,0 +1,10 @@
+label: Test condition attached_to_institutions départements
+institution: institution_departement
+prefix: l’
+conditions_generales:
+  - type: attached_to_institution
+type: float
+unit: €
+periodicite: mensuelle
+montant: 17.8
+floorAt: 1

--- a/test_data/benefits/test_condition_attached_to_institution_epcis.yaml
+++ b/test_data/benefits/test_condition_attached_to_institution_epcis.yaml
@@ -1,0 +1,10 @@
+label: Test condition attached_to_institutions epci
+institution: institution_epci
+prefix: l’
+conditions_generales:
+  - type: attached_to_institution
+type: float
+unit: €
+periodicite: mensuelle
+montant: 18
+floorAt: 1

--- a/test_data/benefits/test_profil_beneficiaire_rsa.yaml
+++ b/test_data/benefits/test_profil_beneficiaire_rsa.yaml
@@ -1,5 +1,4 @@
 label: Aide au permis de conduire
-institution: intercommunalite_toulon_provence_mediterranee
 prefix: l’
 conditions_generales:
   - type: regions

--- a/test_data/institutions/institution_caf.yml
+++ b/test_data/institutions/institution_caf.yml
@@ -1,0 +1,6 @@
+name: CAF de l'Ain
+imgSrc: img/institutions/logo_caf_ain.png
+type: caf
+code_siren: "779311224"
+departments:
+  - "01"

--- a/test_data/institutions/institution_commune.yml
+++ b/test_data/institutions/institution_commune.yml
@@ -1,0 +1,6 @@
+name: Ville de Bar-le-Duc
+imgSrc: img/institutions/logo_ville_bar_le_duc.png
+prefix: de la
+type: commune
+code_insee: "55029"
+code_siren: "215500299"

--- a/test_data/institutions/institution_departement.yml
+++ b/test_data/institutions/institution_departement.yml
@@ -1,0 +1,5 @@
+name: Département Alpes-Maritimes
+imgSrc: img/institutions/logo_cd06.png
+type: departement
+code_insee: "06"
+code_siren: "220600019"

--- a/test_data/institutions/institution_epci.yml
+++ b/test_data/institutions/institution_epci.yml
@@ -1,0 +1,5 @@
+name: Communauté d'agglomération du Grand Verdun
+imgSrc: img/institutions/logo_ca_grand_verdun.png
+prefix: de la
+type: epci
+code_siren: "200049187"

--- a/tests/reforms/aides_jeunes/test_aides_jeunes_reform.py
+++ b/tests/reforms/aides_jeunes/test_aides_jeunes_reform.py
@@ -1,16 +1,15 @@
 import os
 import pytest
 from openfisca_france import FranceTaxBenefitSystem
-from openfisca_france.scenarios import init_single_entity
 from openfisca_france_local.aides_jeunes_reform import aides_jeunes_reform_dynamic
 
 
 @pytest.mark.parametrize("bogus_benefit_folder", [
     'test_missing_condition_key',
     'test_missing_profile_key',
-])
+    ])
 def test_bogus_benefit_structure(bogus_benefit_folder):
-    with pytest.raises(KeyError):
+    with pytest.raises(NotImplementedError):
         base_tbs = FranceTaxBenefitSystem()
         benefits_path = os.path.join('test_data/bogus_benefits/', bogus_benefit_folder)
         aides_jeunes_reform_dynamic(base_tbs, benefits_path)

--- a/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
+++ b/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
@@ -251,3 +251,42 @@
   - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
   output:
     test_pas_de_profile: 0
+
+- period: 2022-11
+  name: Condition attached_to_institution communes
+  reforms:
+  - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
+  input:
+    depcom: [55029, 38000]
+  output:
+    test_condition_attached_to_institution_communes: [16.8, 0]
+
+
+- period: 2022-11
+  name: Condition attached_to_institution départements
+  reforms:
+  - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
+  input:
+    depcom: ['06100']
+  output:
+    test_condition_attached_to_institution_departements: [17.8]
+
+
+- period: 2022-11
+  name: Condition attached_to_institution epcis
+  reforms:
+  - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
+  - openfisca_france_local.epci_test_factory.epci_reform
+  input:
+    depcom: [55505]
+  output:
+    test_condition_attached_to_institution_epcis: [18]
+
+- period: 2022-11
+  name: Condition attached_to_institution caf + msa
+  reforms:
+  - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
+  input:
+    depcom: ['01100']
+  output:
+    test_condition_attached_to_institution_caf: [19]


### PR DESCRIPTION
# Description

La condition `attached_to_instititution` n'as pas été développée jusqu'a maintenant car elle n'est pas explicitée dans le fichier yaml d'une aide.
Cette condition est une condition géographique dont le périmètre est régi par l'institution en question.
Les aides avec cette condition ont un champ `institution` dans lequel réside une chaine de caractères qui correspond a nom d'un fichier dans un autre répertoire sans leur extension `.yml` (pas compatible avec `.yaml` pour le moment)

Cette particularité technique implique que la condition ne peut pas être traitée comme les autres car il faudrait intégrer toutes les institutions dans openfisca, ce qui ne semble pas souhaitable.

Cette PR propose donc d'agir avant l'importation des aides dans le tax and benefit system, juste après avoir lu les fichiers d'aides et les avoir transformés en `dict`, on :
- supprime la condition `attached_to_institution` des `conditions_generales`
- lit le fichier de l'institution correspondante grâce au champ `institution`
- ajoute une condition géographique équivalente aux informations du fichier `institution` dans les conditions générales

### Modifié en même temps : 

Dans le `boy scout spirit` je me suis dit qu'il était ok de faire quelques changements : 
- simplification de la gestion des path par défaut
- changement du type d'erreur remontée en cas de condition ou profil inconnu, on passe de `KeyError` à `NotImplementedError`

### Added

- Ajoute la gestion de la condition `attaches_to_institution`