### PR TITLE
[Crash} Corrige le chargement du chemin du fichier dans le package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+
+## [6.7.2] - 2023-11-23
+
+_Pour les changements détaillés et les discussions associées, référencez la pull request [#192](https://github.com/openfisca/openfisca-france-local/pull/192)
+
+### Fixed
+
+- Corrige le problème de chargement du fichier contenant les *epcis* de la réforme `epci_test_factory` introduit dans la release `6.7.1`
+
 ## [6.7.1] - 2023-11-21
 
 _Pour les changements détaillés et les discussions associées, référencez la pull request [#190](https://github.com/openfisca/openfisca-france-local/pull/190)

--- a/openfisca_france_local/epci_test_factory.py
+++ b/openfisca_france_local/epci_test_factory.py
@@ -2,6 +2,7 @@
 from openfisca_france.model.base import Variable, Menage, MONTH
 from openfisca_core import reforms
 
+from importlib.resources import as_file, files
 import pandas as pd
 
 
@@ -26,9 +27,10 @@ def epci_test_factory(groups, code):
 
 class epci_reform(reforms.Reform):
     def apply(self):
-        raw = pd.read_excel('openfisca_france_local/epcicom2020.xlsx')
-        raw.insee = raw.insee.astype('|S5')
-        df = raw[['siren', 'insee', 'raison_sociale']].groupby('siren')
+        with as_file(files('openfisca_france_local').joinpath('epcicom2020.xlsx')) as path:
+            raw = pd.read_excel(path)
+            raw.insee = raw.insee.astype('|S5')
+            df = raw[['siren', 'insee', 'raison_sociale']].groupby('siren')
 
         for siren in df.groups:
             self.add_variable(epci_test_factory(df, siren))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.7.1',
+    version='6.7.2',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[


### PR DESCRIPTION
# Description
Nous avons introduit un bug dans la PR [ Corrige warning deprecated path() dans la réforme epci_test_factory #190](https://github.com/openfisca/openfisca-france-local/pull/190).

En effet, le chemin utilisé pour charger le fichier des `epcis` n'est valable que dans se dépôt là, si on appelle la réforme dans un autre projet, le fichier n'est pas trouvé car le chemin est en dure.
