### PR TITLE
Ajoute variable sous_contrat_engagement_jeune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+## [6.11.0] - 2023-12-03
+
+_Pour les changements détaillés et les discussions associées, référencez la pull request [#193](https://github.com/openfisca/openfisca-france-local/pull/193)_
+
+### Added
+
+- Ajoute la variable `sous_contrat_engagement_jeune`
+
+### Changed
+
+- Modifie le calcul du dispositif Revenu Solidarite Jeune de la métropole de Lyon pour utiliser la nouvelle variable plutôt que le montant du CEJ
+
 ## [6.10.0] - 2023-11-28
 
 _Pour les changements détaillés et les discussions associées, référencez la pull request [#186](https://github.com/openfisca/openfisca-france-local/pull/186)_

--- a/openfisca_france_local/metropoles/lyon/revenu_solidaire_jeune.py
+++ b/openfisca_france_local/metropoles/lyon/revenu_solidaire_jeune.py
@@ -3,6 +3,13 @@ from openfisca_france.model.base import (
     Variable, Individu, MONTH, TypesActivite)
 
 
+class sous_contrat_engagement_jeune(Variable):
+    value_type = bool
+    entity = Individu
+    definition_period = MONTH
+    label = "Est actuellement en Contrat Engagement Jeune"
+
+
 class revenu_solidaire_jeune(Variable):
     value_type = float
     entity = Individu
@@ -20,8 +27,8 @@ class revenu_solidaire_jeune(Variable):
         rsa = individu.famille('rsa', period)
         aah = individu('aah', period)
         aeeh = individu.famille('aeeh', period)
-        contrat_engagement_jeune = individu('contrat_engagement_jeune', period)
-        prestations_incompatibles = rsa + aah + aeeh + contrat_engagement_jeune
+        sous_contrat_engagement_jeune = individu('sous_contrat_engagement_jeune', period)
+        prestations_incompatibles = rsa + aah + aeeh + sous_contrat_engagement_jeune
         eligibilite_prestations = prestations_incompatibles == 0
 
         pas_en_etude = individu('activite', period) != TypesActivite.etudiant

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.10.0',
+    version='6.11.0',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[

--- a/tests/metropoles/lyon/revenu_solidaire_jeune.yaml
+++ b/tests/metropoles/lyon/revenu_solidaire_jeune.yaml
@@ -8,7 +8,7 @@
     rsa: [0, 0, 0, 0, 0, 1, 0, 0, 0, 0]
     aah: [0, 0, 0, 0, 0, 0, 1, 0, 0, 0]
     aeeh: [0, 0, 0, 0, 0, 0, 0, 1, 0, 0]
-    contrat_engagement_jeune: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0]
+    sous_contrat_engagement_jeune: [False, False, False, False, False, False, False, False, True, False]
     activite: ['inactif', 'inactif', 'inactif', 'inactif', 'inactif', 'inactif', 'inactif', 'inactif', 'inactif', 'etudiant']
   output:
     revenu_solidaire_jeune: [420, 0, 0, 0, 420, 0, 0, 0, 0, 0]
@@ -20,7 +20,7 @@
   input:
     age: [18, 18, 18, 18]
     depcom: [69003, 69003, 69003, 69003]
-    contrat_engagement_jeune: [0, 0, 0, 0]
+    sous_contrat_engagement_jeune: [False, False, False, False]
     salaire_net: [1, 400, 401, 101]
     indemnites_stage: [0, 0, 0, 101]
     ppa: [0, 0, 0, 101]


### PR DESCRIPTION
# Description : 
Lors d'une simulation ou un individu a peu de ressources, le CEJ peut être calculé donc la variable correspondante dispose d'un montant **éligible** mais qui n'implique pas qu'il est effectivement touché.
Cela court-circuite le calcul pour le RSJ.

Cette variable vient corriger ce problème.