### PR TITLE
Réforme dynamique : Corrige le problème de non création de conditions lorsqu'un profil est présent deux fois

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## [6.11.2] - 2023-12-06
+
+_Pour les changements détaillés et les discussions associées, référencez la pull request [#194](https://github.com/openfisca/openfisca-france-local/pull/194)_
+
+### Fixed
+
+- Corrige le problème de la réforme dynamique qui ne crée qu'une condition lorsqu'un profil est présent plus d'une fois
+
 ## [6.11.1] - 2023-12-06
 
 _Pour les changements détaillés et les discussions associées, référencez la pull request [#196](https://github.com/openfisca/openfisca-france-local/pull/196)_

--- a/openfisca_france_local/convert_benefit_conditions_to_parameters.py
+++ b/openfisca_france_local/convert_benefit_conditions_to_parameters.py
@@ -109,15 +109,32 @@ def profils_to_node_data(profils: 'list[dict]'):
             data['profils'].update({profil['type']: {}})
 
     def add_profil_with_conditions(data: dict, profil: dict):
+        def condition_already_exists_in_node(profil_condition, conditions_in_node_data) -> bool:
+            conditions_with_operator_fields = ['age', 'quotient_familial', 'situation_handicap']
+
+            conditions_types = profil_condition.keys()
+
+            if len(conditions_types) == 0:
+                return False
+
+            for type in conditions_types:
+                if type in conditions_in_node_data:
+                    if type in conditions_with_operator_fields:
+                        operator = list(profil_condition[type])[0]
+                        return operator in conditions_in_node_data[type]
+                    else:
+                        return True
+
         if 'conditions' not in data['profils'][profil['type']]:
             data['profils'][profil['type']] = {'conditions': {}}
 
         profil_condition = data['profils'][profil['type']]['conditions']
         conditions_in_node_data = conditions_to_node_data(profil['conditions'])['conditions']
 
-        for type in profil_condition.keys():
-            if type in conditions_in_node_data:
-                raise NotImplementedError('Une aide avec deux profils de même type ne peux pas avoir de conditions de même type pour chacun de ses profils')
+        if condition_already_exists_in_node(profil_condition, conditions_in_node_data):
+            raise NotImplementedError(
+                'La réforme dynamique ne gère pas encore les aides avec deux profils de même type qui ont des conditions de même type pour chacun de ses profils identiques'
+                )
 
         profil_condition.update(conditions_in_node_data)
 

--- a/openfisca_france_local/convert_benefit_conditions_to_parameters.py
+++ b/openfisca_france_local/convert_benefit_conditions_to_parameters.py
@@ -105,17 +105,20 @@ def conditions_to_node_data(conditions: 'list[dict]') -> dict:
 
 def profils_to_node_data(profils: 'list[dict]'):
     def create_profils_field(data: dict, profil: dict):
-        data['profils'].update({profil['type']: {}})
+        if profil['type'] not in data['profils']:
+            data['profils'].update({profil['type']: {}})
 
     def add_profil_with_conditions(data: dict, profil: dict):
-        data['profils'][profil['type']].update(conditions_to_node_data(profil['conditions']))
+        if 'conditions' not in data['profils'][profil['type']]:
+            data['profils'][profil['type']] = {'conditions': {}}
+
+        data['profils'][profil['type']]['conditions'].update(conditions_to_node_data(profil['conditions'])['conditions'])
 
     def add_boolean_profil(data: dict, profil: dict):
         date = '2020-01-01'
         data['profils'][profil['type']] = {date: {'value': True}}
 
     data: dict = {'profils': {}}
-
     for profil in profils:
         create_profils_field(data, profil)
         if 'conditions' in profil:

--- a/openfisca_france_local/convert_benefit_conditions_to_parameters.py
+++ b/openfisca_france_local/convert_benefit_conditions_to_parameters.py
@@ -114,6 +114,11 @@ def profils_to_node_data(profils: 'list[dict]'):
 
         profil_condition = data['profils'][profil['type']]['conditions']
         conditions_in_node_data = conditions_to_node_data(profil['conditions'])['conditions']
+
+        for type in profil_condition.keys():
+            if type in conditions_in_node_data:
+                raise NotImplementedError('Une aide avec deux profils de même type ne peux pas avoir de conditions de même type pour chacun de ses profils')
+
         profil_condition.update(conditions_in_node_data)
 
     def add_boolean_profil(data: dict, profil: dict):

--- a/openfisca_france_local/convert_benefit_conditions_to_parameters.py
+++ b/openfisca_france_local/convert_benefit_conditions_to_parameters.py
@@ -112,13 +112,16 @@ def profils_to_node_data(profils: 'list[dict]'):
         if 'conditions' not in data['profils'][profil['type']]:
             data['profils'][profil['type']] = {'conditions': {}}
 
-        data['profils'][profil['type']]['conditions'].update(conditions_to_node_data(profil['conditions'])['conditions'])
+        profil_condition = data['profils'][profil['type']]['conditions']
+        conditions_in_node_data = conditions_to_node_data(profil['conditions'])['conditions']
+        profil_condition.update(conditions_in_node_data)
 
     def add_boolean_profil(data: dict, profil: dict):
         date = '2020-01-01'
         data['profils'][profil['type']] = {date: {'value': True}}
 
     data: dict = {'profils': {}}
+
     for profil in profils:
         create_profils_field(data, profil)
         if 'conditions' in profil:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.11.1',
+    version='6.11.2',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[

--- a/test_data/benefits/test_2_same_type_profils with_same_type_condition_different_operator.yml
+++ b/test_data/benefits/test_2_same_type_profils with_same_type_condition_different_operator.yml
@@ -1,0 +1,15 @@
+label: "Carte Génération - Apprentis : aide au transport"
+conditions_generales: []
+profils:
+  - type: apprenti
+    conditions:
+      - type: age
+        operator: <
+        value: 26
+  - type: apprenti
+    conditions:
+      - type: age
+        operator: '>'
+        value: 27
+type: float
+montant: 200

--- a/test_data/benefits/test_double_profile_meme_type.yml
+++ b/test_data/benefits/test_double_profile_meme_type.yml
@@ -1,0 +1,15 @@
+label: "Carte Génération - Apprentis : aide au transport"
+conditions_generales: []
+profils:
+  - type: apprenti
+    conditions:
+      - type: age
+        operator: <
+        value: 26
+  - type: apprenti
+    conditions:
+      - type: departements
+        values:
+          - "01"
+type: float
+montant: 200

--- a/test_data/benefits/test_multiple_profil_meme_type.yaml
+++ b/test_data/benefits/test_multiple_profil_meme_type.yaml
@@ -1,0 +1,13 @@
+label: "Carte Génération - Apprentis : aide au transport"
+conditions_generales: []
+profils:
+  - type: apprenti
+    conditions:
+      - type: age
+        operator: <
+        value: 26
+  - type: apprenti
+    conditions:
+      - type: boursier
+type: float
+montant: 200

--- a/test_data/bogus_benefits/test_2_same_type_profils_with_same_type_condition/benefit.yml
+++ b/test_data/bogus_benefits/test_2_same_type_profils_with_same_type_condition/benefit.yml
@@ -1,0 +1,15 @@
+label: "Carte Génération - Apprentis : aide au transport"
+conditions_generales: []
+profils:
+  - type: apprenti
+    conditions:
+      - type: age
+        operator: <
+        value: 26
+  - type: apprenti
+    conditions:
+      - type: age
+        operator: <
+        value: 27
+type: float
+montant: 200

--- a/tests/reforms/aides_jeunes/test_aides_jeunes_reform.py
+++ b/tests/reforms/aides_jeunes/test_aides_jeunes_reform.py
@@ -7,6 +7,7 @@ from openfisca_france_local.aides_jeunes_reform import aides_jeunes_reform_dynam
 @pytest.mark.parametrize("bogus_benefit_folder", [
     'test_missing_condition_key',
     'test_missing_profile_key',
+    'test_2_same_type_profils_with_same_type_condition',
     ])
 def test_bogus_benefit_structure(bogus_benefit_folder):
     with pytest.raises(NotImplementedError):

--- a/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
+++ b/tests/reforms/aides_jeunes/test_aides_jeunes_reform.yaml
@@ -261,7 +261,6 @@
   output:
     test_condition_attached_to_institution_communes: [16.8, 0]
 
-
 - period: 2022-11
   name: Condition attached_to_institution départements
   reforms:
@@ -270,7 +269,6 @@
     depcom: ['06100']
   output:
     test_condition_attached_to_institution_departements: [17.8]
-
 
 - period: 2022-11
   name: Condition attached_to_institution epcis
@@ -290,3 +288,14 @@
     depcom: ['01100']
   output:
     test_condition_attached_to_institution_caf: [19]
+
+- period: 2022-11
+  name: Test fichier d'aide avec 2 profils de même type
+  reforms:
+  - openfisca_france_local.aides_jeunes_reform.aides_jeunes_reform_dynamic
+  input:
+    age: [20, 29]
+    apprenti: [True, True]
+    boursier: [False, True]
+  output:
+    test_multiple_profil_meme_type: [200, 200]


### PR DESCRIPTION
# Description 

Si un fichier `yaml` présente deux profils de même type, la deuxième condition écrase la première.