### PR TITLE
Ajoute un job dans la CI pour jouer les tests python

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,6 +43,31 @@ jobs:
         with:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.openfisca-dependencies }}
+  test-python:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        openfisca-dependencies: [minimal, maximal]
+    needs: [ build ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9.9
+      - name: Cache build
+        id: restore-build
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.openfisca-dependencies }}
+      - run: |
+          shopt -s globstar
+          openfisca test tests/**/*.py
+        if: matrix.openfisca-dependencies != 'minimal'
+
   test-yaml:
     runs-on: ubuntu-20.04
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## [6.11.4] - 2024-01-03
+
+_Pour les changements détaillés et les discussions associées, référencez la pull request [#201](https://github.com/openfisca/openfisca-france-local/pull/201)_
+
+### Added
+
+- Ajoute un job dans la CI pour lancer les tests en `.py`
+
 ## [6.11.3] - 2023-12-12
 
 _Pour les changements détaillés et les discussions associées, référencez la pull request [#197](https://github.com/openfisca/openfisca-france-local/pull/197)_

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.11.3',
+    version='6.11.4',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[


### PR DESCRIPTION
Les tests écrits en python ne sont pas exécutés, cette PR ajoute un job dans le workflow de la CI qui lance ces tests.