### PR TITLE
Modifie l'authentification à PYPI dans le job de déploiement de la CI pour utiliser un Token API

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -133,8 +133,8 @@ jobs:
     needs: [ check-for-functional-changes ]
     if: needs.check-for-functional-changes.outputs.status == 'success'
     env:
-      PYPI_USERNAME: openfisca-bot
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      PYPI_USERNAME: __token__
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_OPENFISCA_FRANCE_LOCAL }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -156,6 +156,6 @@ jobs:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.openfisca-dependencies }}
       - name: Upload a Python package to PyPi
-        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
+        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_TOKEN
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+
+## [6.11.5] - 2024-01-08
+
+_Pour les changements détaillés et les discussions associées, référencez la pull request [#202](https://github.com/openfisca/openfisca-france-local/pull/202)_
+
+### Added
+
+- Modifie l'authentification à Pypi pour se connecter via un token suite à l'obligation d'utiliser la double authentification (2FA)
+
 ## [6.11.4] - 2024-01-03
 
 _Pour les changements détaillés et les discussions associées, référencez la pull request [#201](https://github.com/openfisca/openfisca-france-local/pull/201)_

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.11.4',
+    version='6.11.5',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[


### PR DESCRIPTION
# Description

Suite à l'obligation de l 'authentification à double facteur, nous devons mettre à jour la manière dont la CI s'authentifie pour publier les paquets sur Pypi.

Nous avons choisi d'utiliser un token.