### PR TITLE
Modifie le job de déploiement dans la CI pour autoriser le trusted publishing

### DIFF
--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .github/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .github/* setup.py"
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -132,9 +132,11 @@ jobs:
         openfisca-dependencies: [maximal]
     needs: [ check-for-functional-changes ]
     if: needs.check-for-functional-changes.outputs.status == 'success'
-    env:
-      PYPI_USERNAME: openfisca-bot
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    permissions:
+            #id-token is mandatory for trusted publishing
+            id-token: write
+            #contents is mandatory for git tag publishing
+            contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -156,6 +158,6 @@ jobs:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.openfisca-dependencies }}
       - name: Upload a Python package to PyPi
-        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
+        uses: pypa/gh-action-pypi-publish@release/v1
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -110,7 +110,7 @@ jobs:
   # The `deploy` job is dependent on the output of the `check-for-functional-changes` job.
   check-for-functional-changes:
     runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
+    # if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
     needs: [ check-version-and-changelog ]
     outputs:
       status: ${{ steps.stop-early.outputs.status }}
@@ -159,5 +159,8 @@ jobs:
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.openfisca-dependencies }}
       - name: Upload a Python package to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
+        # With statement only to specify testPy destination, Pypi is default
+        with:
+          repository-url: https://test.pypi.org/legacy/
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -110,7 +110,7 @@ jobs:
   # The `deploy` job is dependent on the output of the `check-for-functional-changes` job.
   check-for-functional-changes:
     runs-on: ubuntu-20.04
-    # if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
+    if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
     needs: [ check-version-and-changelog ]
     outputs:
       status: ${{ steps.stop-early.outputs.status }}
@@ -159,8 +159,5 @@ jobs:
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.openfisca-dependencies }}
       - name: Upload a Python package to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
-        # With statement only to specify testPy destination, Pypi is default
-        with:
-          repository-url: https://test.pypi.org/legacy/
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'Topic :: Scientific/Engineering :: Information Analysis',
         ],
     description='Extension OpenFisca pour nos partenariats avec les collectivités territoriales',
+    long_description_content_type='text/markdown',
     keywords='benefit france france-local microsimulation social tax',
     license='http://www.fsf.org/licensing/licenses/agpl-3.0.html',
     url='https://github.com/openfisca/openfisca-france-local',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 
 setup(
-    name='OpenFisca-France-Local',
+    name='OpenFisca-France-Local-test-trusted-publisher',
     version='6.11.4',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 
 setup(
-    name='OpenFisca-France-Local-test-trusted-publisher',
+    name='OpenFisca-France-Local',
     version='6.11.4',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',


### PR DESCRIPTION
# Description

Suite à l'obligation de l 'authentification à double facteur, nous devons mettre à jour la manière dont la CI s'authentifie pour publier les paquets sur Pypi.
PyPi recommande d'utiliser les [`trusted publisher`](https://docs.pypi.org/trusted-publishers/), une technique qui génère des tokens avec une durée de courte pour chaque déploiement au lieu d'avoir un token actif en permanence. ([OpenID Connect (OIDC)](https://openid.net/connect/) standard)

# Détails
## Modification du workflow
Techniquement, un `GITHUB_TOKEN` est crée pour chaque workflow ou job sur github action.

Pour que cela fonctionne du côté CI, il faut que le workflow ou le job utilise un `GITHUB_TOKEN` qui ait l'autorisation de demander le token OICD (le token d'authentification à PyPi).

Il est possible (et recommandé) d'accorder cette permission dans un `job` précis.
Pour nous, c'est le job `deploy`.

Il faut demander les accès en écriture sur la permission `id-token` avec les lignes suivantes dans le job qui déploi: 
```yaml
    permissions:
            id-token: write
```
Ceci est détaillé dans la [documentation relative](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings)
Le `GITHUB_TOKEN` dispose d'accès par défaut ([Permissions for the GitHub token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token))

Lorsqu'on précise les accès pour un job avec la mention de la clé `permissions` comme décris précédemment, toutes les permissions non spécifiées perdent leurs accès.

La dernière étape du job `deploy` est de créer un `tag` sur le dépôt git, c'est la permission `contents` qui règle ça (cf [Repository permissions for "Contents"](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents))

Par défauts le job a accès mais vu qu'on précise la liste des permissions pour le token de déploiement il faut aussi préciser les accès pour la création du tag git.
C'est la ligne 
```yaml
contents: write
```
## Modification du `setup.py`

La github action qu'on utilise pour la publication du package sur PyPi ([gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish/)) utilise la commande `twine check --strict` qui est une pratique + sûr (au moins d'après le mainteneur du projet qui a répondu à ma question [ici](https://github.com/pypa/gh-action-pypi-publish/discussions/209)).

J'ai du mal à comprendre l'erreur que lève cette commande (on peut la voir sur [ce workflow](https://github.com/openfisca/openfisca-france-local/actions/runs/7408575380/job/20157138534)), mais l'ajout de la ligne `long_description_content_type='text/markdown',` règle le soucis.

On peut voir une cohérence avec notre dépôt car en général on associe à `long_description` le contenu du fichier `readme` et le nôtre est en markdown mais comme nous ne donnons pas de valeur à `long_description`, j'ai du mal à comprendre pourquoi on devrait préciser que c'est du markdown.
