### PR TITLE
Met à jour la contrainte max de version OpenFisca France

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [6.11.9] - 2024-03-12
+
+_Pour les changements détaillés et les discussions associées, référencez la pull request [#208](https://github.com/openfisca/openfisca-france-local/pull/208)_
+
 ## [6.11.8] - 2024-03-12
 
 _Pour les changements détaillés et les discussions associées, référencez la pull request [#207](https://github.com/openfisca/openfisca-france-local/pull/207)_

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.11.8',
+    version='6.11.9',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'OpenFisca-Core >= 40.0.1, < 42',
-        'OpenFisca-France >= 153.0.1, < 159',
+        'OpenFisca-France >= 153.0.1, < 160',
         'pandas >= 1.5.3, <2.0'
         ],
     extras_require={


### PR DESCRIPTION
Complète la mise jour de la contrainte de version max de la dépendance Openfisca France https://github.com/openfisca/openfisca-france-local/pull/207