### PR TITLE
Modélisation de la mutuelle communale de la ville de Montpellier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [6.14.0] - 2024-10-02
+
+_Pour les changements détaillés et les discussions associées, référencez la pull request [#216](https://github.com/openfisca/openfisca-france-local/pull/216)_
+
+### Added
+
+- Ajoute la variable `montpellier_mutuelle_communale`
+
 ## [6.13.0] - 2024-09-24
 
 _Pour les changements détaillés et les discussions associées, référencez la pull request [#215](https://github.com/openfisca/openfisca-france-local/pull/215)_

--- a/openfisca_france_local/communes/montpellier/eligibilite.py
+++ b/openfisca_france_local/communes/montpellier/eligibilite.py
@@ -1,0 +1,10 @@
+from openfisca_france.model.base import Menage, MONTH, Variable
+
+class montpellier_eligibilite_residence(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    label = "Éligibilité résidentielle d'un ménage aux dipositifs de Montpellier"
+
+    def formula(menage, period):
+        return menage('depcom', period) == b'34172'

--- a/openfisca_france_local/communes/montpellier/montpellier_mutuelle_communale.py
+++ b/openfisca_france_local/communes/montpellier/montpellier_mutuelle_communale.py
@@ -1,0 +1,15 @@
+from openfisca_france.model.base import Variable, MONTH, not_, Famille
+
+class montpellier_mutuelle_communale(Variable):
+    value_type = bool
+    entity = Famille
+    definition_period = MONTH
+    label = "Mutuelle communale de la ville de Montpellier"
+    reference = [
+        "https://www.montpellier.fr/4884-mutuelle-communale.htm"
+        ]
+
+    def formula(famille, period):
+        eligibilite_residentielle = famille.demandeur.menage('montpellier_eligibilite_residence', period)
+        eligibilite_css = famille('css_cmu_acs_eligibilite', period)
+        return eligibilite_residentielle & not_(eligibilite_css)

--- a/openfisca_france_local/communes/montpellier/montpellier_mutuelle_communale.py
+++ b/openfisca_france_local/communes/montpellier/montpellier_mutuelle_communale.py
@@ -11,5 +11,6 @@ class montpellier_mutuelle_communale(Variable):
 
     def formula(famille, period):
         eligibilite_residentielle = famille.demandeur.menage('montpellier_eligibilite_residence', period)
-        eligibilite_css = famille('css_cmu_acs_eligibilite', period)
+        css_participation_forfaitaire = famille('css_participation_forfaitaire_montant', period)
+        eligibilite_css = css_participation_forfaitaire > 0
         return eligibilite_residentielle & not_(eligibilite_css)

--- a/openfisca_france_local/communes/montpellier/montpellier_mutuelle_communale.py
+++ b/openfisca_france_local/communes/montpellier/montpellier_mutuelle_communale.py
@@ -11,6 +11,7 @@ class montpellier_mutuelle_communale(Variable):
 
     def formula(famille, period):
         eligibilite_residentielle = famille.demandeur.menage('montpellier_eligibilite_residence', period)
-        css_participation_forfaitaire = famille('css_participation_forfaitaire_montant', period)
-        eligibilite_css = css_participation_forfaitaire > 0
-        return eligibilite_residentielle & not_(eligibilite_css)
+        css_participation_forfaitaire = famille('css_participation_forfaitaire', period)
+        cmu_c = famille('cmu_c', period)
+        eligibilite_css_cmu_c = (css_participation_forfaitaire > 0) | cmu_c
+        return eligibilite_residentielle * not_(eligibilite_css_cmu_c)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='OpenFisca-France-Local',
-    version='6.13.0',
+    version='6.14.0',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     classifiers=[

--- a/tests/communes/montpellier/montpellier_mutuelle_communale.yml
+++ b/tests/communes/montpellier/montpellier_mutuelle_communale.yml
@@ -2,6 +2,6 @@
   period: 2024-10
   input:
     depcom: ["34172", "34172", "68400", "68400"]
-    css_cmu_acs_eligibilite: [False, True, True, False]
+    css_participation_forfaitaire_montant: [0, 20, 25, 30]
   output:
     montpellier_mutuelle_communale: [True, False, False, False]

--- a/tests/communes/montpellier/montpellier_mutuelle_communale.yml
+++ b/tests/communes/montpellier/montpellier_mutuelle_communale.yml
@@ -1,0 +1,7 @@
+- name: "Égibilité à la mutuelle communale de Montpellier"
+  period: 2024-10
+  input:
+    depcom: ["34172", "34172", "68400", "68400"]
+    css_cmu_acs_eligibilite: [False, True, True, False]
+  output:
+    montpellier_mutuelle_communale: [True, False, False, False]

--- a/tests/communes/montpellier/montpellier_mutuelle_communale.yml
+++ b/tests/communes/montpellier/montpellier_mutuelle_communale.yml
@@ -1,7 +1,8 @@
 - name: "Égibilité à la mutuelle communale de Montpellier"
   period: 2024-10
   input:
-    depcom: ["34172", "34172", "68400", "68400"]
-    css_participation_forfaitaire_montant: [0, 20, 25, 30]
+    depcom: ["34172","34172", "34172", "68400", "68400"]
+    css_participation_forfaitaire_montant: [0, 0, 20, 25, 30]
+    cmu_c: [False, True, False, False, False]
   output:
-    montpellier_mutuelle_communale: [True, False, False, False]
+    montpellier_mutuelle_communale: [True, False, False, False, False]


### PR DESCRIPTION
Reprise de [cette logique](https://github.com/betagouv/aides-jeunes/blob/bc76ad32e1f698a749be7caf67bb3ecc55bf2cc9/data/benefits/additional-attributes/index.ts#L17-L31) présente dans le simulateur Aides Jeunes pour l'éligibilité à la CSS (ex CMU) :

```js
  css_participation_forfaitaire: {
    extra: [
      {
        id: "cmu_c",
        entity: "familles",
        type: "bool",
        openfiscaPeriod: "thisMonth",
      },
    ],
    compute: function (result, period) {
      return result.cmu_c?.[period]
        ? true
        : result.css_participation_forfaitaire?.[period] || 0
    },
  },
```